### PR TITLE
attempt to fix #360

### DIFF
--- a/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
+++ b/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
@@ -98,7 +98,13 @@ private abstract class ScalaCheckRunner extends Runner {
       names flatMap { name =>
         import util.Pretty.{pretty, Params}
 
-        val params = applyCmdParams(properties.foldLeft(Parameters.default)((params, props) => props.overrideParameters(params)))
+        //If there are no command line arguments provided then override defaults with what is defined in the
+        //Property. If there are any command line arguments provided, override the values defined on the
+        //Property with those defined via the command line.
+        val paramsFromProperty = properties.foldLeft(Parameters.default)((params, props) => props.overrideParameters(params))
+        val noCmdArgsProvided = Parameters.hasSameCmdArgs(applyCmdParams(Parameters.default), Parameters.default)
+        val params = if (noCmdArgsProvided) paramsFromProperty else applyCmdParams(paramsFromProperty)
+
         val propertyFilter = params.propFilter.map(_.r)
 
         for ((`name`, prop) <- props) {

--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -148,6 +148,26 @@ object Test {
       val initialSeed: Option[rng.Seed] = None
     }
 
+    /**
+     * Compares if two supplied Parameters p1, p2 have equal values for all
+     * arguments that can be supplied via the command line:
+     * - minSuccessfulTests
+     * - minSize
+     * - maxSize
+     * - workers
+     * - maxDiscardRatio
+     * - propFilter
+     *
+     */
+    def hasSameCmdArgs(p1: Parameters, p2: Parameters): Boolean = {
+      p1.minSuccessfulTests == p2.minSuccessfulTests &&
+      p1.minSize            == p2.minSize            &&
+      p1.maxSize            == p2.maxSize            &&
+      p1.workers            == p2.workers            &&
+      p1.maxDiscardRatio    == p2.maxDiscardRatio    &&
+      p1.propFilter         == p2.propFilter
+    }
+
     /** Verbose console reporter test parameters instance. */
     val defaultVerbose: Parameters = default.withTestCallback(ConsoleReporter(2))
   }
@@ -371,7 +391,6 @@ object Test {
 
   /** Check a set of properties. */
   def checkProperties(prms: Parameters, ps: Properties): Seq[(String,Result)] = {
-    val params = ps.overrideParameters(prms)
     val propertyFilter = prms.propFilter.map(_.r)
 
     ps.properties.filter {
@@ -380,12 +399,12 @@ object Test {
       case (name, p)  =>
         val testCallback = new TestCallback {
           override def onPropEval(n: String, t: Int, s: Int, d: Int) =
-            params.testCallback.onPropEval(name,t,s,d)
+            prms.testCallback.onPropEval(name,t,s,d)
           override def onTestResult(n: String, r: Result) =
-            params.testCallback.onTestResult(name,r)
+            prms.testCallback.onTestResult(name,r)
         }
 
-        val res = check(params.withTestCallback(testCallback), p)
+        val res = check(prms.withTestCallback(testCallback), p)
         (name,res)
     }
   }


### PR DESCRIPTION
This is an attempt to fix the functionality outlined in #360. Given the following Properties, the expected behaviour of running the tests with and without arguments and running the Properties through the main method, with and without arguments is documented.

__BasicProps__:
```
import org.scalacheck.Properties
import org.scalacheck._

object BasicProps extends Properties("Basic") {

  override def overrideParameters(p: Test.Parameters): Test.Parameters =
     p.withMinSuccessfulTests(1000)

  property("should test basic things") =
    Prop.forAll { n: Int => n != 42 }
}
```

Method  | Tests run  | Comments
------- | ---------  | --------
 sbt test-only *BasicProps | 1000 | -
 sbt test-only *BasicProps  -- -s 5  | 5 | -
 sbt test-only *BasicProps  -- -n 10  | 100 | If one override is provided, all values must be overridden
 sbt test:run-main com.example.validation.extra.BasicProps  | 100 | -
 sbt test:run-main com.example.validation.extra.BasicProps -s 5 | 5 | -


__Basic2Props__:

```
import org.scalacheck.Properties
import org.scalacheck._

object Basic2Props extends Properties("Basic2") {

  property("should test basic things") =
    Prop.forAll { n: Int => n != 42 }
}
```

Method  | Tests run  | Comments
------- | ---------  | --------
 sbt test-only *Basic2Props | 100 | -
 sbt test-only *Basic2Props  -- -s 5  | 5 | -
 sbt test-only *Basic2Props  -- -n 10  | 100 | If one override is provided, all values must be overridden or the defaults apply
 sbt test:run-main com.example.validation.extra.Basic2Props  | 100 | -
 sbt test:run-main com.example.validation.extra.Basic2Props -s 5 | 5 | -

