### PR TITLE
make Arbitrary[String] return an arbitrary string

### DIFF
--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -150,7 +150,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
 
   /** Arbitrary instance of String */
   implicit lazy val arbString: Arbitrary[String] =
-    Arbitrary(arbitrary[List[Char]] map (_.mkString))
+    Arbitrary(Gen.anyStr)
 
   /** Arbitrary instance of Date */
   implicit lazy val arbDate: Arbitrary[java.util.Date] =

--- a/src/test/scala/org/scalacheck/generators/CodepointSpecification.scala
+++ b/src/test/scala/org/scalacheck/generators/CodepointSpecification.scala
@@ -22,7 +22,9 @@ object GenCodepointSpecification extends Properties("Gen") {
 
     property("emptyPlaneCP is not defined") = forAll(Gen.emptyPlaneCP){cp => !Character.isDefined(cp)} 
 
-    property("supplementalPUCP is private use") = forAll(Gen.supplementalPUCP){cp => Character.getType(cp) == Character.PRIVATE_USE}
-    property("supplementalPUCP is defined") = forAll(Gen.supplementalPUCP)(Character.isDefined)
+    property("supplementalPUCP is private use or end of block") = forAll(Gen.supplementalPUCP){cp => (
+        (Character.getType(cp) == Character.PRIVATE_USE) ||
+        (cp == 0xFFFFF || cp == 0xFFFFE || cp == 0x10FFFF || cp == 0x10FFFE)
+    )}
 
 }

--- a/src/test/scala/org/scalacheck/generators/CodepointSpecification.scala
+++ b/src/test/scala/org/scalacheck/generators/CodepointSpecification.scala
@@ -13,11 +13,11 @@ object GenCodepointSpecification extends Properties("Gen") {
     property("nonCharCP is not defined") = forAll(Gen.nonCharCP) { cp => !Character.isDefined(cp)}
 
     property("plainBMPCP is defined") = forAll(Gen.plainBMPCP)(Character.isDefined)
-    property("plainBMPCP is no surrogate") = forAll(Gen.plainBMPCP)(cp => !Character.isSurrogate(cp.toChar))
+    property("plainBMPCP is no surrogate") = forAll(Gen.plainBMPCP)(cp => !Character.isHighSurrogate(cp.toChar) && !Character.isLowSurrogate(cp.toChar))
     property("plainBMPCP is in the BMP") = forAll(Gen.plainBMPCP)(cp => !Character.isSupplementaryCodePoint(cp))
     property("plainBMPCP is not private use") = forAll(Gen.plainBMPCP) {cp => Character.getType(cp) != Character.PRIVATE_USE}
 
-    property("validBMPCP is no surrogate") = forAll(Gen.validBMPCP)(cp => !Character.isSurrogate(cp.toChar))
+    property("validBMPCP is no surrogate") = forAll(Gen.validBMPCP)(cp => !Character.isHighSurrogate(cp.toChar) && !Character.isLowSurrogate(cp.toChar))
     property("validBMPCP is in the BMP") = forAll(Gen.validBMPCP)(cp => !Character.isSupplementaryCodePoint(cp))
 
     property("emptyPlaneCP is not defined") = forAll(Gen.emptyPlaneCP){cp => !Character.isDefined(cp)} 

--- a/src/test/scala/org/scalacheck/generators/CodepointSpecification.scala
+++ b/src/test/scala/org/scalacheck/generators/CodepointSpecification.scala
@@ -1,0 +1,28 @@
+package org.scalacheck
+
+import Prop.forAll
+
+object GenCodepointSpecification extends Properties("Gen") {
+    //private use
+    property("privateUseCP is defined") = forAll(Gen.privateUseCP)(Character.isDefined)
+    property("privateUseCP is no control character") = forAll(Gen.privateUseCP) {cp => !Character.isISOControl(cp) }
+    property("privateUseCP is no letter or digit") = forAll(Gen.privateUseCP) { cp => !Character.isLetterOrDigit(cp)}
+    property("privateUseCP is not whitespace") = forAll(Gen.privateUseCP) { cp => !Character.isWhitespace(cp)}
+    property("privateUseCP is in cat private use") = forAll(Gen.privateUseCP) {cp => Character.getType(cp) == Character.PRIVATE_USE}
+
+    property("nonCharCP is not defined") = forAll(Gen.nonCharCP) { cp => !Character.isDefined(cp)}
+
+    property("plainBMPCP is defined") = forAll(Gen.plainBMPCP)(Character.isDefined)
+    property("plainBMPCP is no surrogate") = forAll(Gen.plainBMPCP)(cp => !Character.isSurrogate(cp.toChar))
+    property("plainBMPCP is in the BMP") = forAll(Gen.plainBMPCP)(cp => !Character.isSupplementaryCodePoint(cp))
+    property("plainBMPCP is not private use") = forAll(Gen.plainBMPCP) {cp => Character.getType(cp) != Character.PRIVATE_USE}
+
+    property("validBMPCP is no surrogate") = forAll(Gen.validBMPCP)(cp => !Character.isSurrogate(cp.toChar))
+    property("validBMPCP is in the BMP") = forAll(Gen.validBMPCP)(cp => !Character.isSupplementaryCodePoint(cp))
+
+    property("emptyPlaneCP is not defined") = forAll(Gen.emptyPlaneCP){cp => !Character.isDefined(cp)} 
+
+    property("supplementalPUCP is private use") = forAll(Gen.supplementalPUCP){cp => Character.getType(cp) == Character.PRIVATE_USE}
+    property("supplementalPUCP is defined") = forAll(Gen.supplementalPUCP)(Character.isDefined)
+
+}


### PR DESCRIPTION
To open discussion to broaden what an arbitrary string entails.

ScalaCheck is so useful to me because it often finds edge-cases that I didn't. To make `Arbitrary[String]` by default return a relatively well-behaved string runs counter to that.

In reality, Strings are messy. They can contain private use characters, supplemental characters, unassigned characters, and even invalid unicode with unpaired surrogate characters.

If a program thinks it can deal with arbitrary strings, and wants to check that with scalacheck, right now it avoids checking the spots where the bugs probably are.

Dealing with some subset of strings is entirely reasonable for some application, and this PR adds some generators for some different definitions of valid strings.