### PR TITLE
Remove shrinking from gen-based Prop.forAll

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -114,7 +114,7 @@ object GenSpecification extends Properties("Gen") {
   }
 
   property("choose-infinite-double-fix-zero-defect-379") = {
-    Prop.forAllNoShrink(listOfN(3, choose(NegativeInfinity, PositiveInfinity))) { xs =>
+    Prop.forAll(listOfN(3, choose(NegativeInfinity, PositiveInfinity))) { xs =>
       xs.exists(_ != 0d)
     }
   }
@@ -429,7 +429,7 @@ object GenSpecification extends Properties("Gen") {
 
   //// See https://github.com/rickynils/scalacheck/issues/209
   property("uniform double #209") =
-    Prop.forAllNoShrink(Gen.choose(1000000, 2000000)) { n =>
+    Prop.forAll(Gen.choose(1000000, 2000000)) { n =>
       var i = 0
       var sum = 0d
       var seed = rng.Seed(n.toLong)
@@ -445,7 +445,7 @@ object GenSpecification extends Properties("Gen") {
 
   property("uniform long #209") = {
     val scale = 1d / Long.MaxValue
-    Prop.forAllNoShrink(Gen.choose(1000000, 2000000)) { n =>
+    Prop.forAll(Gen.choose(1000000, 2000000)) { n =>
       var i = 0
       var sum = 0d
       var seed = rng.Seed(n.toLong)

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -804,106 +804,97 @@ object Prop {
 
   }
 
-  /** Universal quantifier for an explicit generator. Shrinks failed arguments
-   *  with the default shrink function for the type */
+  /** Universal quantifier for an explicit generator. */
   def forAll[T1,P](
     g1: Gen[T1])(
     f: T1 => P)(implicit
     p: P => Prop,
-    s1: Shrink[T1],
     pp1: T1 => Pretty
-  ): Prop = forAllShrink[T1,P](g1, shrink[T1])(f)
+  ): Prop = forAllNoShrink(g1)(f)
 
-  /** Universal quantifier for two explicit generators. Shrinks failed arguments
-   *  with the default shrink function for the type */
+  /** Universal quantifier for two explicit generators. */
   def forAll[T1,T2,P](
     g1: Gen[T1], g2: Gen[T2])(
     f: (T1,T2) => P)(implicit
     p: P => Prop,
-    s1: Shrink[T1], pp1: T1 => Pretty,
-    s2: Shrink[T2], pp2: T2 => Pretty
-  ): Prop = forAll(g1)(t => forAll(g2)(f(t, _:T2)))
+    pp1: T1 => Pretty,
+    pp2: T2 => Pretty
+  ): Prop = forAllNoShrink(g1, g2)(f)
 
-  /** Universal quantifier for three explicit generators. Shrinks failed arguments
-   *  with the default shrink function for the type */
+  /** Universal quantifier for three explicit generators. */
   def forAll[T1,T2,T3,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3])(
     f: (T1,T2,T3) => P)(implicit
     p: P => Prop,
-    s1: Shrink[T1], pp1: T1 => Pretty,
-    s2: Shrink[T2], pp2: T2 => Pretty,
-    s3: Shrink[T3], pp3: T3 => Pretty
-  ): Prop = forAll(g1)(t => forAll(g2,g3)(f(t, _:T2, _:T3)))
+    pp1: T1 => Pretty,
+    pp2: T2 => Pretty,
+    pp3: T3 => Pretty
+  ): Prop = forAllNoShrink(g1, g2, g3)(f)
 
-  /** Universal quantifier for four explicit generators. Shrinks failed arguments
-   *  with the default shrink function for the type */
+  /** Universal quantifier for four explicit generators. */
   def forAll[T1,T2,T3,T4,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4])(
     f: (T1,T2,T3,T4) => P)(implicit
     p: P => Prop,
-    s1: Shrink[T1], pp1: T1 => Pretty,
-    s2: Shrink[T2], pp2: T2 => Pretty,
-    s3: Shrink[T3], pp3: T3 => Pretty,
-    s4: Shrink[T4], pp4: T4 => Pretty
-  ): Prop = forAll(g1)(t => forAll(g2,g3,g4)(f(t, _:T2, _:T3, _:T4)))
+    pp1: T1 => Pretty,
+    pp2: T2 => Pretty,
+    pp3: T3 => Pretty,
+    pp4: T4 => Pretty
+  ): Prop = forAllNoShrink(g1, g2, g3, g4)(f)
 
-  /** Universal quantifier for five explicit generators. Shrinks failed arguments
-   *  with the default shrink function for the type */
+  /** Universal quantifier for five explicit generators. */
   def forAll[T1,T2,T3,T4,T5,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5])(
     f: (T1,T2,T3,T4,T5) => P)(implicit
     p: P => Prop,
-    s1: Shrink[T1], pp1: T1 => Pretty,
-    s2: Shrink[T2], pp2: T2 => Pretty,
-    s3: Shrink[T3], pp3: T3 => Pretty,
-    s4: Shrink[T4], pp4: T4 => Pretty,
-    s5: Shrink[T5], pp5: T5 => Pretty
-  ): Prop = forAll(g1)(t => forAll(g2,g3,g4,g5)(f(t, _:T2, _:T3, _:T4, _:T5)))
+    pp1: T1 => Pretty,
+    pp2: T2 => Pretty,
+    pp3: T3 => Pretty,
+    pp4: T4 => Pretty,
+    pp5: T5 => Pretty
+  ): Prop = forAllNoShrink(g1, g2, g3, g4, g5)(f)
 
-  /** Universal quantifier for six explicit generators. Shrinks failed arguments
-   *  with the default shrink function for the type */
+  /** Universal quantifier for six explicit generators. */
   def forAll[T1,T2,T3,T4,T5,T6,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6])(
     f: (T1,T2,T3,T4,T5,T6) => P)(implicit
     p: P => Prop,
-    s1: Shrink[T1], pp1: T1 => Pretty,
-    s2: Shrink[T2], pp2: T2 => Pretty,
-    s3: Shrink[T3], pp3: T3 => Pretty,
-    s4: Shrink[T4], pp4: T4 => Pretty,
-    s5: Shrink[T5], pp5: T5 => Pretty,
-    s6: Shrink[T6], pp6: T6 => Pretty
-  ): Prop = forAll(g1)(t => forAll(g2,g3,g4,g5,g6)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6)))
+    pp1: T1 => Pretty,
+    pp2: T2 => Pretty,
+    pp3: T3 => Pretty,
+    pp4: T4 => Pretty,
+    pp5: T5 => Pretty,
+    pp6: T6 => Pretty
+  ): Prop = forAllNoShrink(g1, g2, g3, g4, g5, g6)(f)
 
-  /** Universal quantifier for seven explicit generators. Shrinks failed arguments
-   *  with the default shrink function for the type */
+  /** Universal quantifier for seven explicit generators. */
   def forAll[T1,T2,T3,T4,T5,T6,T7,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7])(
     f: (T1,T2,T3,T4,T5,T6,T7) => P)(implicit
     p: P => Prop,
-    s1: Shrink[T1], pp1: T1 => Pretty,
-    s2: Shrink[T2], pp2: T2 => Pretty,
-    s3: Shrink[T3], pp3: T3 => Pretty,
-    s4: Shrink[T4], pp4: T4 => Pretty,
-    s5: Shrink[T5], pp5: T5 => Pretty,
-    s6: Shrink[T6], pp6: T6 => Pretty,
-    s7: Shrink[T7], pp7: T7 => Pretty
-  ): Prop = forAll(g1)(t => forAll(g2,g3,g4,g5,g6,g7)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6, _:T7)))
+    pp1: T1 => Pretty,
+    pp2: T2 => Pretty,
+    pp3: T3 => Pretty,
+    pp4: T4 => Pretty,
+    pp5: T5 => Pretty,
+    pp6: T6 => Pretty,
+    pp7: T7 => Pretty
+  ): Prop = forAllNoShrink(g1, g2, g3, g4, g5, g6, g7)(f)
 
-  /** Universal quantifier for eight explicit generators. Shrinks failed arguments
-   *  with the default shrink function for the type */
+  /** Universal quantifier for eight explicit generators. */
   def forAll[T1,T2,T3,T4,T5,T6,T7,T8,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7], g8: Gen[T8])(
     f: (T1,T2,T3,T4,T5,T6,T7,T8) => P)(implicit
     p: P => Prop,
-    s1: Shrink[T1], pp1: T1 => Pretty,
-    s2: Shrink[T2], pp2: T2 => Pretty,
-    s3: Shrink[T3], pp3: T3 => Pretty,
-    s4: Shrink[T4], pp4: T4 => Pretty,
-    s5: Shrink[T5], pp5: T5 => Pretty,
-    s6: Shrink[T6], pp6: T6 => Pretty,
-    s7: Shrink[T7], pp7: T7 => Pretty,
-    s8: Shrink[T8], pp8: T8 => Pretty
-  ): Prop = forAll(g1)(t => forAll(g2,g3,g4,g5,g6,g7,g8)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6, _:T7, _:T8)))
+    pp1: T1 => Pretty,
+    pp2: T2 => Pretty,
+    pp3: T3 => Pretty,
+    pp4: T4 => Pretty,
+    pp5: T5 => Pretty,
+    pp6: T6 => Pretty,
+    pp7: T7 => Pretty,
+    pp8: T8 => Pretty
+  ): Prop = forAllNoShrink(g1, g2, g3, g4, g5, g6, g7, g8)(f)
 
   /** Converts a function into a universally quantified property */
   def forAll[A1,P] (

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -907,7 +907,7 @@ object Prop {
   def forAll[T1,P](
     g1: Gen[T1])(
     f: T1 => P)(implicit
-    p: P => Prop,
+    pv: P => Prop,
     pp1: T1 => Pretty
   ): Prop = Prop { prms0 =>
     val (prms, seed) = startSeed(prms0)

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -548,7 +548,7 @@ object Prop {
 
   /** Universal quantifier for an explicit generator. Does not shrink failed
    *  test cases. */
-  @deprecated("Use 'forAll'.  Here only for bincompat")
+  @deprecated("Use 'forAll'.  Here only for bincompat", "1.15.0")
   def forAllNoShrink[T1,P](
     g1: Gen[T1])(
     f: T1 => P)(implicit
@@ -558,7 +558,7 @@ object Prop {
 
   /** Universal quantifier for two explicit generators.
    *  Does not shrink failed test cases. */
-  @deprecated("Use 'forAll'.  Here only for bincompat")
+  @deprecated("Use 'forAll'.  Here only for bincompat", "1.15.0")
   def forAllNoShrink[T1,T2,P](
     g1: Gen[T1], g2: Gen[T2])(
     f: (T1,T2) => P)(implicit
@@ -569,7 +569,7 @@ object Prop {
 
   /** Universal quantifier for three explicit generators.
    *  Does not shrink failed test cases. */
-  @deprecated("Use 'forAll'.  Here only for bincompat")
+  @deprecated("Use 'forAll'.  Here only for bincompat", "1.15.0")
   def forAllNoShrink[T1,T2,T3,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3])(
     f: (T1,T2,T3) => P)(implicit
@@ -581,7 +581,7 @@ object Prop {
 
   /** Universal quantifier for four explicit generators.
    *  Does not shrink failed test cases. */
-  @deprecated("Use 'forAll'.  Here only for bincompat")
+  @deprecated("Use 'forAll'.  Here only for bincompat", "1.15.0")
   def forAllNoShrink[T1,T2,T3,T4,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4])(
     f: (T1,T2,T3,T4) => P)(implicit
@@ -594,7 +594,7 @@ object Prop {
 
   /** Universal quantifier for five explicit generators.
    *  Does not shrink failed test cases. */
-  @deprecated("Use 'forAll'.  Here only for bincompat")
+  @deprecated("Use 'forAll'.  Here only for bincompat", "1.15.0")
   def forAllNoShrink[T1,T2,T3,T4,T5,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5])(
     f: (T1,T2,T3,T4,T5) => P)(implicit
@@ -608,7 +608,7 @@ object Prop {
 
   /** Universal quantifier for six explicit generators.
    *  Does not shrink failed test cases. */
-  @deprecated("Use 'forAll'.  Here only for bincompat")
+  @deprecated("Use 'forAll'.  Here only for bincompat", "1.15.0")
   def forAllNoShrink[T1,T2,T3,T4,T5,T6,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6])(
     f: (T1,T2,T3,T4,T5,T6) => P)(implicit
@@ -623,7 +623,7 @@ object Prop {
 
   /** Universal quantifier for seven explicit generators.
    *  Does not shrink failed test cases. */
-  @deprecated("Use 'forAll'.  Here only for bincompat")
+  @deprecated("Use 'forAll'.  Here only for bincompat", "1.15.0")
   def forAllNoShrink[T1,T2,T3,T4,T5,T6,T7,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7])(
     f: (T1,T2,T3,T4,T5,T6,T7) => P)(implicit
@@ -639,7 +639,7 @@ object Prop {
 
   /** Universal quantifier for eight explicit generators.
    *  Does not shrink failed test cases. */
-  @deprecated("Use 'forAll'.  Here only for bincompat")
+  @deprecated("Use 'forAll'.  Here only for bincompat", "1.15.0")
   def forAllNoShrink[T1,T2,T3,T4,T5,T6,T7,T8,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7], g8: Gen[T8])(
     f: (T1,T2,T3,T4,T5,T6,T7,T8) => P)(implicit

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -659,7 +659,7 @@ object Prop {
     f: A1 => P)(implicit
     pv: P => Prop,
     a1: Arbitrary[A1], pp1: A1 => Pretty
-  ): Prop = forAllNoShrink(arbitrary[A1])(f)
+  ): Prop = forAll(arbitrary[A1])(f)
 
   /** Converts a function into a universally quantified property */
   def forAllNoShrink[A1,A2,P](
@@ -667,7 +667,7 @@ object Prop {
     pv: P => Prop,
     a1: Arbitrary[A1], pp1: A1 => Pretty,
     a2: Arbitrary[A2], pp2: A2 => Pretty
-  ): Prop = forAllNoShrink(arbitrary[A1], arbitrary[A2])(f)
+  ): Prop = forAll(arbitrary[A1], arbitrary[A2])(f)
 
   /** Converts a function into a universally quantified property */
   def forAllNoShrink[A1,A2,A3,P](
@@ -676,7 +676,7 @@ object Prop {
     a1: Arbitrary[A1], pp1: A1 => Pretty,
     a2: Arbitrary[A2], pp2: A2 => Pretty,
     a3: Arbitrary[A3], pp3: A3 => Pretty
-  ): Prop = forAllNoShrink(arbitrary[A1], arbitrary[A2], arbitrary[A3])(f)
+  ): Prop = forAll(arbitrary[A1], arbitrary[A2], arbitrary[A3])(f)
 
   /** Converts a function into a universally quantified property */
   def forAllNoShrink[A1,A2,A3,A4,P](
@@ -686,7 +686,7 @@ object Prop {
     a2: Arbitrary[A2], pp2: A2 => Pretty,
     a3: Arbitrary[A3], pp3: A3 => Pretty,
     a4: Arbitrary[A4], pp4: A4 => Pretty
-  ): Prop = forAllNoShrink(arbitrary[A1], arbitrary[A2], arbitrary[A3], arbitrary[A4])(f)
+  ): Prop = forAll(arbitrary[A1], arbitrary[A2], arbitrary[A3], arbitrary[A4])(f)
 
   /** Converts a function into a universally quantified property */
   def forAllNoShrink[A1,A2,A3,A4,A5,P](
@@ -697,7 +697,7 @@ object Prop {
     a3: Arbitrary[A3], pp3: A3 => Pretty,
     a4: Arbitrary[A4], pp4: A4 => Pretty,
     a5: Arbitrary[A5], pp5: A5 => Pretty
-  ): Prop = forAllNoShrink(arbitrary[A1], arbitrary[A2], arbitrary[A3], arbitrary[A4], arbitrary[A5])(f)
+  ): Prop = forAll(arbitrary[A1], arbitrary[A2], arbitrary[A3], arbitrary[A4], arbitrary[A5])(f)
 
   /** Converts a function into a universally quantified property */
   def forAllNoShrink[A1,A2,A3,A4,A5,A6,P](
@@ -709,7 +709,7 @@ object Prop {
     a4: Arbitrary[A4], pp4: A4 => Pretty,
     a5: Arbitrary[A5], pp5: A5 => Pretty,
     a6: Arbitrary[A6], pp6: A6 => Pretty
-  ): Prop = forAllNoShrink(arbitrary[A1], arbitrary[A2], arbitrary[A3], arbitrary[A4], arbitrary[A5], arbitrary[A6])(f)
+  ): Prop = forAll(arbitrary[A1], arbitrary[A2], arbitrary[A3], arbitrary[A4], arbitrary[A5], arbitrary[A6])(f)
 
   /** Converts a function into a universally quantified property */
   def forAllNoShrink[A1,A2,A3,A4,A5,A6,A7,P](
@@ -723,7 +723,7 @@ object Prop {
     a6: Arbitrary[A6], pp6: A6 => Pretty,
     a7: Arbitrary[A7], pp7: A7 => Pretty
   ): Prop = {
-    forAllNoShrink(arbitrary[A1], arbitrary[A2], arbitrary[A3], arbitrary[A4], arbitrary[A5], arbitrary[A6],
+    forAll(arbitrary[A1], arbitrary[A2], arbitrary[A3], arbitrary[A4], arbitrary[A5], arbitrary[A6],
       arbitrary[A7])(f)
   }
 
@@ -740,7 +740,7 @@ object Prop {
     a7: Arbitrary[A7], pp7: A7 => Pretty,
     a8: Arbitrary[A8], pp8: A8 => Pretty
   ): Prop = {
-    forAllNoShrink(arbitrary[A1], arbitrary[A2], arbitrary[A3], arbitrary[A4], arbitrary[A5], arbitrary[A6],
+    forAll(arbitrary[A1], arbitrary[A2], arbitrary[A3], arbitrary[A4], arbitrary[A5], arbitrary[A6],
       arbitrary[A7], arbitrary[A8])(f)
   }
 
@@ -928,7 +928,7 @@ object Prop {
     p: P => Prop,
     pp1: T1 => Pretty,
     pp2: T2 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2)(f(t, _:T2)))
+  ): Prop = forAll(g1)(t => forAll(g2)(f(t, _:T2)))
 
   /** Universal quantifier for three explicit generators. */
   def forAll[T1,T2,T3,P](
@@ -938,7 +938,7 @@ object Prop {
     pp1: T1 => Pretty,
     pp2: T2 => Pretty,
     pp3: T3 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3)(f(t, _:T2, _:T3)))
+  ): Prop = forAll(g1)(t => forAll(g2,g3)(f(t, _:T2, _:T3)))
 
   /** Universal quantifier for four explicit generators. */
   def forAll[T1,T2,T3,T4,P](
@@ -949,7 +949,7 @@ object Prop {
     pp2: T2 => Pretty,
     pp3: T3 => Pretty,
     pp4: T4 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4)(f(t, _:T2, _:T3, _:T4)))
+  ): Prop = forAll(g1)(t => forAll(g2,g3,g4)(f(t, _:T2, _:T3, _:T4)))
 
   /** Universal quantifier for five explicit generators. */
   def forAll[T1,T2,T3,T4,T5,P](
@@ -961,7 +961,7 @@ object Prop {
     pp3: T3 => Pretty,
     pp4: T4 => Pretty,
     pp5: T5 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4,g5)(f(t, _:T2, _:T3, _:T4, _:T5)))
+  ): Prop = forAll(g1)(t => forAll(g2,g3,g4,g5)(f(t, _:T2, _:T3, _:T4, _:T5)))
 
   /** Universal quantifier for six explicit generators. */
   def forAll[T1,T2,T3,T4,T5,T6,P](
@@ -974,7 +974,7 @@ object Prop {
     pp4: T4 => Pretty,
     pp5: T5 => Pretty,
     pp6: T6 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4,g5,g6)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6)))
+  ): Prop = forAll(g1)(t => forAll(g2,g3,g4,g5,g6)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6)))
 
   /** Universal quantifier for seven explicit generators. */
   def forAll[T1,T2,T3,T4,T5,T6,T7,P](
@@ -988,7 +988,7 @@ object Prop {
     pp5: T5 => Pretty,
     pp6: T6 => Pretty,
     pp7: T7 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4,g5,g6,g7)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6, _:T7)))
+  ): Prop = forAll(g1)(t => forAll(g2,g3,g4,g5,g6,g7)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6, _:T7)))
 
   /** Universal quantifier for eight explicit generators. */
   def forAll[T1,T2,T3,T4,T5,T6,T7,T8,P](
@@ -1003,7 +1003,7 @@ object Prop {
     pp6: T6 => Pretty,
     pp7: T7 => Pretty,
     pp8: T8 => Pretty
-  ): Prop = forAllNoShrink(g1)(t => forAllNoShrink(g2,g3,g4,g5,g6,g7,g8)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6, _:T7, _:T8)))
+  ): Prop = forAll(g1)(t => forAll(g2,g3,g4,g5,g6,g7,g8)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6, _:T7, _:T8)))
 
   /** Converts a function into a universally quantified property */
   def forAll[A1,P] (


### PR DESCRIPTION
Shrinking is only safe when used with Arbitrary. Generators can have a smaller range than the global shrinking, which results in invalid shrunken values.

This fixes issues like #129, #260, #317, #370, #442 and #443.

I suspect this is going to be controversial and I completely understand if it's not accepted. I'm opening this to show how I suggest it should be tackled, but it obviously affects people who are currently relying on this behaviour.

EDIT: Note that Haskell's QuickCheck `forAll` [doesn't shrink in this instance](http://hackage.haskell.org/package/QuickCheck-2.12.4/docs/src/Test.QuickCheck.Property.html#forAll) either