### PR TITLE
Always show seed for failing property check

### DIFF
--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -94,7 +94,8 @@ class Properties(val name: String) {
    */
   sealed class PropertySpecifier() {
     def update(propName: String, p: => Prop) = {
-      props += ((name+"."+propName, Prop.delay(p)))
+      val fullName = s"$name.$propName"
+      props += ((fullName, Prop.delay(p).viewSeed(fullName)))
     }
   }
 


### PR DESCRIPTION
This copies the current behavior of `propertyWithSeed(..., None)` into `property(...)`