### PR TITLE
Deprecate overloaded Prop.collect

### DIFF
--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -451,6 +451,7 @@ object Prop {
     try { x; false } catch { case e if c.isInstance(e) => true }
 
   /** Collect data for presentation in test report */
+  @deprecated("Use Prop.forAll(t => Prop.collect(t)(...)) instead of Prop.forAll(Prop.collect(t => ...))", "1.15.0")
   def collect[T, P](f: T => P)(implicit ev: P => Prop): T => Prop = t => Prop { prms =>
     val prop = ev(f(t))
     prop(prms).collect(t)

--- a/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -12,7 +12,7 @@ package org.scalacheck
 import Prop.{
   forAll, falsified, undecided, exception, passed, proved, all,
   atLeastOne, sizedProp, someFailing, noneFailing, Undecided, False, True,
-  Exception, Proof, throws, propBoolean, secure, delay, lzy
+  Exception, Proof, throws, propBoolean, secure, delay, lzy, collect
 }
 import Gen.{ const, fail, oneOf, listOf, Parameters }
 
@@ -176,6 +176,19 @@ object PropSpecification extends Properties("Prop") {
   property("delay") = { delay(???); proved }
 
   property("lzy") = { lzy(???); proved }
+
+  property("collect(t)") = {
+    forAll(collect(_: Boolean)(passed))
+  }
+
+  /* [warn] method Prop.collect is deprecated (since 1.16.0): Use
+   * Prop.forAll(t => Prop.collect(t)(prop))
+   * instead of
+   * Prop.forAll(Prop.collect(prop))
+   */
+  property("collect(t => Prop") = {
+    forAll(collect((_: Boolean) => passed))
+  }
 
   property("Gen.Parameters.withInitialSeed is deterministic") =
     forAll { (p: Prop) =>


### PR DESCRIPTION
In support of #421, this PR deprecates the single-argument `Prop.collect`.   The method collects statistics on the _parameter_ to a property test.  It conflicts with the second version of `Prop.collect` that takes two arguments, a value and a property.   The two overloaded methods confuse the Scala compiler for two reasons 1) because the former accepts an implicit second argument and 2) because collections from the standard library typically extend `PartialFunction`.