### PR TITLE
Add Shrink.suchThat

### DIFF
--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -851,11 +851,11 @@ val shrinkEvenList: Shrink[List[Int]] =
 ```
 
 Note that if a property fails on a value generated through `suchThat`, and is
-later shrunk (see [test case minimisation](#test-case-minimisation) below, the
-value ultimately reported as failing might not satisfy the condition given to
-`suchThat`, although it doesn't change the fact that there _exists_ a failing
-case that does. To avoid confusion, the corresponding shrink for the type can
-use `suchThat` method too.
+later shrunk (see [test case minimisation](#test-case-minimisation) below),
+the value ultimately reported as failing might not satisfy the condition given
+to `suchThat`, although it doesn't change the fact that there _exists_ a
+failing case that does. To avoid confusion, the corresponding shrink for the
+type can use `suchThat` method too.
 
 ### Stateful Testing
 

--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -836,7 +836,8 @@ and lists.
 
 If the generator for a type is restricting the range of valid values by
 construction or using `Gen.suchThat`, the values that fail tests can still be
-shrunk without checking the condition. To avoid that, use `Shrink.suchThat`
+shrunk without checking the condition, and then ultimately be reported as
+failing even though they do not satisfy it. To avoid that, use `Shrink.suchThat`
 with the condition to be maintained:
 
 ```scala
@@ -849,13 +850,6 @@ val genEvenList: Gen[List[Int]] = Gen.sized { size =>
 val shrinkEvenList: Shrink[List[Int]] =
   implicitly[Shrink[List[Int]]].suchThat(_.length % 2 == 0)
 ```
-
-Note that if a property fails on a value generated through `suchThat`, and is
-later shrunk (see [test case minimisation](#test-case-minimisation) below),
-the value ultimately reported as failing might not satisfy the condition given
-to `suchThat`, although it doesn't change the fact that there _exists_ a
-failing case that does. To avoid confusion, the corresponding shrink for the
-type can use `suchThat` method too.
 
 ### Stateful Testing
 

--- a/src/main/scala/org/scalacheck/Shrink.scala
+++ b/src/main/scala/org/scalacheck/Shrink.scala
@@ -17,6 +17,11 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 
 sealed abstract class Shrink[T] extends Serializable {
   def shrink(x: T): Stream[T]
+
+  /** Create a new shrink that only produces values satisfying the given
+   *  condition.
+   */
+  def suchThat(f: T => Boolean): Shrink[T] = Shrink(v => this.shrink(v).filter(f))
 }
 
 trait ShrinkLowPriority {

--- a/src/test/scala/org/scalacheck/ShrinkSpecification.scala
+++ b/src/test/scala/org/scalacheck/ShrinkSpecification.scala
@@ -104,7 +104,7 @@ object ShrinkSpecification extends Properties("Shrink") {
   }
 
   def evenLength(value: List[_]) = value.length % 2 == 0
-  val shrinkEvenLength: Shrink[List[Int]] = implicitly[Shrink[List[Int]]].suchThat(evenLength _)
+  def shrinkEvenLength[A]: Shrink[List[A]] = implicitly[Shrink[List[A]]].suchThat(evenLength _)
 
   property("list suchThat") = {
     forAll { l: List[Int] =>

--- a/src/test/scala/org/scalacheck/ShrinkSpecification.scala
+++ b/src/test/scala/org/scalacheck/ShrinkSpecification.scala
@@ -103,6 +103,15 @@ object ShrinkSpecification extends Properties("Shrink") {
     shrink(e).forall(_.isRight)
   }
 
+  def evenLength(value: List[_]) = value.length % 2 == 0
+  val shrinkEvenLength: Shrink[List[Int]] = implicitly[Shrink[List[Int]]].suchThat(evenLength _)
+
+  property("list suchThat") = {
+    forAll { l: List[Int] =>
+      shrink(l)(shrinkEvenLength).forall(evenLength _)
+    }
+  }
+
   /* Ensure that shrink[T] terminates. (#244)
    *
    * Let's say shrinking "terminates" when the stream of values


### PR DESCRIPTION
When using `Gen.suchThat` or generators that maintain invariants by construction, shrinking can break those invariants. Add `Shrink.suchThat` to ensure no invalid values are shrunk to.