### PR TITLE
Improve errors for test parameters

### DIFF
--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -215,14 +215,21 @@ object Test {
   }
 
   private def assertParams(prms: Parameters) = {
-    import prms._
-    if(
-      minSuccessfulTests <= 0 ||
-      maxDiscardRatio <= 0 ||
-      minSize < 0 ||
-      maxSize < minSize ||
-      workers <= 0
-    ) throw new IllegalArgumentException("Invalid test parameters")
+    if (prms.minSuccessfulTests <= 0)
+      throw new IllegalArgumentException(
+        s"Invalid test parameter: minSuccessfulTests (${prms.minSuccessfulTests}) <= 0")
+    else if (prms.maxDiscardRatio <= 0)
+      throw new IllegalArgumentException(
+        s"Invalid test parameter: maxDiscardRatio (${prms.maxDiscardRatio}) <= 0")
+    else if (prms.minSize < 0)
+      throw new IllegalArgumentException(
+        s"Invalid test parameter: minSize (${prms.minSize}) < 0")
+    else if (prms.maxSize < prms.minSize)
+      throw new IllegalArgumentException(
+        s"Invalid test parameter: maxSize (${prms.maxSize}) < minSize (${prms.minSize})")
+    else if (prms.workers <= 0)
+      throw new IllegalArgumentException(
+        s"Invalid test parameter: workers (${prms.workers}) <= 0")
   }
 
   private[scalacheck] lazy val cmdLineParser = new CmdLineParser {


### PR DESCRIPTION
Invalid test parameters, or mixing and matching test parameters that conflict raises an error, but it's not clear why.  For example,

```
> jvm/testOnly org.scalacheck.util.PrettySpecification -- -n 200 -x 100
[error] Uncaught exception when running org.scalacheck.util.PrettySpecification: java.lang.IllegalArgumentException: Invalid test parameters
[error] sbt.ForkMain$ForkError: java.lang.IllegalArgumentException: Invalid test parameters
[error] 	at org.scalacheck.Test$.assertParams(Test.scala:225)
[error] 	at org.scalacheck.Test$.check(Test.scala:307)
[error] 	at org.scalacheck.ScalaCheckRunner$$anon$2.executeInternal(ScalaCheckFramework.scala:123)
[error] 	at org.scalacheck.ScalaCheckRunner$$anon$2.$anonfun$execute$11(ScalaCheckFramework.scala:113)
[error] 	at org.scalacheck.ScalaCheckRunner$$anon$2.$anonfun$execute$11$adapted(ScalaCheckFramework.scala:112)
```

This change would improve the diagnostics a bit.  For the example above,

```
> jvm/testOnly org.scalacheck.util.PrettySpecification -- -n 200 -x 100
[error] Uncaught exception when running org.scalacheck.util.PrettySpecification: java.lang.IllegalArgumentException: Invalid test parameter: maxSize < minSize
[error] sbt.ForkMain$ForkError: java.lang.IllegalArgumentException: Invalid test parameter: maxSize < minSize
[error] 	at org.scalacheck.Test$.assertParams(Test.scala:225)
[error] 	at org.scalacheck.Test$.check(Test.scala:309)
[error] 	at org.scalacheck.ScalaCheckRunner$$anon$2.executeInternal(ScalaCheckFramework.scala:123)
[error] 	at org.scalacheck.ScalaCheckRunner$$anon$2.$anonfun$execute$11(ScalaCheckFramework.scala:113)
[error] 	at org.scalacheck.ScalaCheckRunner$$anon$2.$anonfun$execute$11$adapted(ScalaCheckFramework.scala:112)
```