### PR TITLE
Remove Cogen.apply with dummy implicit

### DIFF
--- a/src/main/scala/org/scalacheck/Cogen.scala
+++ b/src/main/scala/org/scalacheck/Cogen.scala
@@ -30,11 +30,7 @@ sealed trait Cogen[T] extends Serializable {
 
 object Cogen extends CogenArities with CogenLowPriority with CogenVersionSpecific {
 
-  // for binary compatibility
-  private[scalacheck] def apply[T](ev: Cogen[T]): Cogen[T] = ev
-
-  // https://github.com/typelevel/scalacheck/pull/395#issuecomment-383442015
-  def apply[T](implicit ev: Cogen[T], dummy: Cogen[T]): Cogen[T] = ev
+  def apply[T](implicit ev: Cogen[T]): Cogen[T] = ev
 
   def apply[T](f: T => Long): Cogen[T] = new Cogen[T] {
     def perturb(seed: Seed, t: T): Seed = seed.reseed(f(t))


### PR DESCRIPTION
The change to `Cogen.apply` was flagged as a possible binary compatibility issue in #508.

The basis for this change in #403 was because of some ambiguity in Scala 2.12 with `-Xexperimental`.  

However, the dummy implicit didn't ship with 1.14.0, and its absence didn't seem to be an issue.  It seems downstream projects using `Cogen` haven't had an issue after upgrading to 1.14.0: cats, cats-effect, kittens, enumeratum, scalaz.