### PR TITLE
Adds cache configuration to the Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,16 @@ env:
     - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false
 sudo: false
 
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
+
 matrix:
   include:
     - scala: 2.11.12


### PR DESCRIPTION
Addresses #507 by configuring Travis CI to store .sbt and .ivy2
directories across jobs to make them run faster. 