### PR TITLE
Add Scala.js 1.0 back to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
   matrix:
     - PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=false
     - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false
+    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-M8
 sudo: false
 
 before_cache:
@@ -56,10 +57,14 @@ matrix:
       - for d in */ ; do cd "$d" && sbt test:compile && cd ../ ; done
   exclude:
     - scala: 2.10.7
-      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M8
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-M8
+    - scala: 2.11.12
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-M8
     - jdk: openjdk11
       scala: 2.10.7
     - jdk: openjdk11
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false
+    - jdk: openjdk11
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-M8
+    - jdk: openjdk11
       scala: 2.11.12
-    - scala: 2.13.0
-      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=0.6.28


### PR DESCRIPTION
I've opted to stop building Scala.js on JDK11 to avoid increasing the build count.