### PR TITLE
Remove invalid filter from MiMa

### DIFF
--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -22,7 +22,6 @@ object MimaSettings {
   )
 
   private def removedPrivateClasses = Seq(
-    "org.scalacheck.Platform$EnableReflectiveInstantiation"
   )
 
   private def otherProblems = Seq(


### PR DESCRIPTION
I predict this was a filter that was added only because the build was incorrectly comparing Scalajs with regular Scala.  Once the configuration was fixed in #482, the filter was no longer necessary.   This resets the Mima settings to empty, except for disabling the MiMa 0.5 signature checking rule.