### PR TITLE
Test.Parameters.cpy should be private

### DIFF
--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -132,7 +132,8 @@ object Test {
       sb.toString
     }
 
-    def cpy(
+    /** Copy constructor with named default arguments */
+    private[this] def cpy(
       minSuccessfulTests0: Int = outer.minSuccessfulTests,
       minSize0: Int = outer.minSize,
       maxSize0: Int = outer.maxSize,


### PR DESCRIPTION
The previous version, `cp`, was private.  I don't think there's a reason to expose this: 
 `Test.Parameters.cpy` should be enough of a fluent interface that a copy constructor is unnecessary.