### PR TITLE
Fix output for bad command-line params

### DIFF
--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -104,7 +104,7 @@ sealed abstract class Prop extends Serializable { self =>
         if (Test.check(params, this).passed) 0
         else 1
       case (_, os) =>
-        println("Incorrect options:\n  " + os.mkString(", "))
+        Console.out.println("Incorrect options:\n  " + os.mkString(", "))
         Test.CmdLineParser.printHelp()
         -1
     }

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -104,7 +104,7 @@ sealed abstract class Prop extends Serializable { self =>
         if (Test.check(params, this).passed) 0
         else 1
       case (_, os) =>
-        println(s"Incorrect options: $os")
+        println("Incorrect options:\n  " + os.mkString(", "))
         Test.CmdLineParser.printHelp()
         -1
     }

--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -73,13 +73,13 @@ class Properties(val name: String) {
         val res = Test.checkProperties(params, this)
         val numFailed = res.count(!_._2.passed)
         if (numFailed > 0) {
-          println(s"Found $numFailed failing properties.")
+          Console.out.println(s"Found $numFailed failing properties.")
           System.exit(1)
         } else {
           System.exit(0)
         }
       case (_, os) =>
-        println("Incorrect options:\n  " + os.mkString(", "))
+        Console.out.println("Incorrect options:\n  " + os.mkString(", "))
         Test.CmdLineParser.printHelp()
         System.exit(-1)
     }

--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -79,7 +79,7 @@ class Properties(val name: String) {
           System.exit(0)
         }
       case (_, os) =>
-        println(s"Incorrect options: $os")
+        println("Incorrect options:\n  " + os.mkString(", "))
         Test.CmdLineParser.printHelp()
         System.exit(-1)
     }

--- a/src/main/scala/org/scalacheck/util/CmdLineParser.scala
+++ b/src/main/scala/org/scalacheck/util/CmdLineParser.scala
@@ -51,9 +51,9 @@ private[scalacheck] trait CmdLineParser {
     else None
 
   def printHelp(): Unit = {
-    println("Available options:")
+    Console.out.println("Available options:")
     opts.foreach { opt =>
-      println("  " + opt.names.map("-"+_).mkString(", ") + ": " + opt.help)
+      Console.out.println("  " + opt.names.map("-"+_).mkString(", ") + ": " + opt.help)
     }
   }
 

--- a/src/main/scala/org/scalacheck/util/ConsoleReporter.scala
+++ b/src/main/scala/org/scalacheck/util/ConsoleReporter.scala
@@ -26,11 +26,11 @@ class ConsoleReporter(val verbosity: Int, val columnWidth: Int)
     if(verbosity > 0) {
       if(name == "") {
         val s = (if(res.passed) "+ " else "! ") + pretty(res, prettyPrms)
-        printf("\r%s\n", format(s, "", "", columnWidth))
+        println(format(s, "", "", columnWidth))
       } else {
         val s = (if(res.passed) "+ " else "! ") + name + ": " +
           pretty(res, prettyPrms)
-        printf("\r%s\n", format(s, "", "", columnWidth))
+        println(format(s, "", "", columnWidth))
       }
     }
   }


### PR DESCRIPTION
This fixes #527 but also switches to `Console.out.println` in a few places, and removes a strange use of `printf` and carriage returns in the `ConsoleReporter`.  I don't entirely grok the latter, but I don't think it serves any purpose.

