### PR TITLE
Fix for #530

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -260,6 +260,15 @@ object Gen extends GenArities with GenVersionSpecific {
   /** Generator parameters, used by [[org.scalacheck.Gen.apply]] */
   sealed abstract class Parameters extends Serializable { outer =>
 
+    override def toString: String = {
+      val sb = new StringBuilder
+      sb.append("Parameters(")
+      sb.append(s"size=$size, ")
+      sb.append(s"initialSeed=$initialSeed, ")
+      sb.append(s"useLegacyShrinking=$useLegacyShrinking)")
+      sb.toString
+    }
+
     /**
      * The size of the generated value. Generator implementations are
      * allowed to freely interpret (or ignore) this value. During test

--- a/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -223,4 +223,9 @@ object PropSpecification extends Properties("Prop") {
     val prop = Prop.forAll(Bogus.gen) { b => Prop(false) }
     Prop(prop(params).failure && !Bogus.shrunk)
   }
+
+  // make sure the two forAlls are seeing independent values
+  property("regression #530: failure to slide seed") =
+    forAll((x: Int) => (x >= 0) ==> true) &&
+    forAll((x: Int) => (x < 0) ==> true)
 }


### PR DESCRIPTION
Here's the basic issue:

When using viewSeed, we need to put an initialSeed in the
Gen.Parameters used to evaluate the Prop, so we can recover
the seed later and display it. So far, so good.

In some cases, we need to "slide" the seed that's embedded
in the parameters, so we don't reuse it. Any time we need
to evaluate several properties and don't want identical
RNG state (which could lead to identical inputs) we need
to slide.

We were missing a "slide" in flatMap -- we were reusing
the same parameters in both cases. Since flatMap was used
to define && (via for-comprehension) that meant that when
you said p0 && p1, you'd use the same seed for both if
viewSeed was set.

Refined's property was unusual, but valid. Basically, one
property had (x >= 0) ==> and one had (x < 0) ==>. So no
single x value would satisfy both, but on average you'd
satisfy each 50% of the time, and together you'd get
a non-discarded case about 25% of the time.

Previously, this worked OK. But since 1.14.0 we started
always displaying seeds. This meant that the bug associated
with failing to slide manifested, and we always generated
the same x value for both sides of the property. This
meant we ended up discarding every x generated.

The fix was to slide correctly in this case. I also added
a toString to Gen.Parameters which was missing, since this
helped with debugging.