### PR TITLE
Set up a repeatable release process.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,6 +145,8 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
 lazy val js = project.in(file("js"))
   .settings(sharedSettings: _*)
   .settings(
+    // remove scala 2.10 since scala.js dropped support
+    crossScalaVersions := Seq("2.11.12", "2.12.9", scalaVersion.value),
     scalaJSStage in Global := FastOptStage,
     libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
   )
@@ -162,6 +164,7 @@ lazy val native = project.in(file("native"))
   .settings(
     doc in Compile := (doc in Compile in jvm).value,
     scalaVersion := "2.11.12",
+    crossScalaVersions := Seq("2.11.12"),
     // TODO: re-enable MiMa for native once published
     mimaPreviousArtifacts := Set(),
     libraryDependencies ++= Seq(

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+# overview:
+#  - before running this script, follow steps 1-3.
+#  - running this script counts as step 4.
+#  - after running this script, follow step 5.
+#
+# step 1: double-check scala.js and scala native versions.
+#
+# step 2: tag the release
+#
+# step 3: edit build.sbt
+#    a. set versionNumber to this release number (e.g. "1.14.2" or "1.14.3-M1")
+#       this version could include RC or M but should not include SNAPSHOT.
+#    b. set isRelease to true
+#
+# step 4: start the actual release
+#    a. run ./release.sh publishSigned
+#    b. you need to have PGP set up to work with SBT.
+#       we'll invoke SBT 5 times (jvm + 2js + 2native)
+#       so you'll need to enter your password 5 times.
+#       it's annoying :/
+#
+# step 5: edit build.sbt again
+#    a. set versionNumber to the next release number (e.g. "1.14.3")
+#       note -- don't include SNAPSHOT, RC, or M in this version.
+#    b. set isRelease back to false
+
+usage() {
+    echo "usage: $0 [compile | test | package | publishLocal | publishSigned]"
+    exit 1
+}
+
+runsbt() {
+    sbt "$1"
+    RES=$?
+    if [ $RES -ne 0 ]; then
+        echo "sbt '$1' failed: $RES"
+        exit $RES
+    fi
+}
+
+if [ $# -ne 1 ]; then usage; fi
+
+case "$1" in
+    compile|test|package|publishLocal)
+        CMD="$1";;
+    publishSigned)
+        egrep -q '^lazy val isRelease = true$' build.sbt
+        if [ $? -ne 0 ]; then
+            echo "isRelease is not true in build.sbt. fix this!"
+            echo "also make sure versionNumber is correct!"
+            usage
+        fi
+        CMD="$1";;
+    *) echo "unknown argument: $1"; usage;;
+esac
+
+# step 4a: jvm release
+runsbt "+ jvm/$CMD"
+
+# step 4b: js releases
+SCALAJS_VERSION="0.6.28" runsbt "+ js/$CMD"
+SCALAJS_VERSION="1.0.0-M8" runsbt "+ js/$CMD"
+
+# step 4c: native releases
+SCALANATIVE_VERSION="0.3.9" runsbt "+ native/$CMD"
+SCALANATIVE_VERSION="0.4.0-M2" runsbt "+ native/$CMD"


### PR DESCRIPTION
I had to make a few tweaks to build.sbt to get things reliably building for me
in a sustainable way. Once I got that working, I set up a release.sh script
that I can successfully use to cross-build, cross-test, and cross-publish.

The following commands are useful during the release process:

```
    ./release.sh compile        # build along all axes
    ./release.sh test           # ensure all tests pass
    ./release.sh package        # ensure we can package everythign
    ./release.sh publishSigned  # actually publish a signed release
```

Note that to publish you currently have to (temporarily) modify build.sbt to
change a few variables. You also have to log into Sonatype to close/publish the
release (assuming all its checks pass).