### PR TITLE
Clean-up the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,19 +5,11 @@
 /build
 /.settings
 /dist
-/.Test.scala.swp
-target
 /lib_managed
 /src_managed
 
-# /project/
-/project/boot
-/project/project/
-/project/target/
-/project/build/target
-
-/examples/simple-sbt/project/
-/examples/simple-sbt/target/
+# sbt
+target/
 
 # Intellij
 .idea

--- a/examples/simple-sbt/project/build.properties
+++ b/examples/simple-sbt/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.0


### PR DESCRIPTION
First pass at getting rid of extraneous stuff.

Add missing `build.properties` to simple-sbt example.