### PR TITLE
Auto-set isRelease in release script

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ scalaVersionSettings
 
 lazy val versionNumber = "1.14.2"
 
-lazy val isRelease = false
+val isRelease = SettingKey[Boolean]("isRelease")
 
 lazy val travisCommit = Option(System.getenv().get("TRAVIS_COMMIT"))
 
@@ -25,14 +25,16 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
 
   name := "scalacheck",
 
+  isRelease := false,
+
   version := {
     val suffix =
-      if (isRelease) ""
+      if (isRelease.value) ""
       else travisCommit.map("-" + _.take(7)).getOrElse("") + "-SNAPSHOT"
     versionNumber + suffix
   },
 
-  isSnapshot := !isRelease,
+  isSnapshot := !isRelease.value,
 
   organization := "org.scalacheck",
 
@@ -122,7 +124,7 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
   publishMavenStyle := true,
 
   // Travis should only publish snapshots
-  publishArtifact := !(isRelease && travisCommit.isDefined),
+  publishArtifact := !(isRelease.value && travisCommit.isDefined),
 
   publishArtifact in Test := false,
 

--- a/release.sh
+++ b/release.sh
@@ -12,7 +12,6 @@
 # step 3: edit build.sbt
 #    a. set versionNumber to this release number (e.g. "1.14.2" or "1.14.3-M1")
 #       this version could include RC or M but should not include SNAPSHOT.
-#    b. set isRelease to true
 #
 # step 4: start the actual release
 #    a. run ./release.sh publishSigned
@@ -24,7 +23,6 @@
 # step 5: edit build.sbt again
 #    a. set versionNumber to the next release number (e.g. "1.14.3")
 #       note -- don't include SNAPSHOT, RC, or M in this version.
-#    b. set isRelease back to false
 
 usage() {
     echo "usage: $0 [compile | test | package | publishLocal | publishSigned]"
@@ -35,7 +33,7 @@ runsbt() {
     sbt "$1"
     RES=$?
     if [ $RES -ne 0 ]; then
-        echo "sbt '$1' failed: $RES"
+        echo "sbt 'set every isRelease := true' '$1' failed: $RES"
         exit $RES
     fi
 }
@@ -43,15 +41,7 @@ runsbt() {
 if [ $# -ne 1 ]; then usage; fi
 
 case "$1" in
-    compile|test|package|publishLocal)
-        CMD="$1";;
-    publishSigned)
-        egrep -q '^lazy val isRelease = true$' build.sbt
-        if [ $? -ne 0 ]; then
-            echo "isRelease is not true in build.sbt. fix this!"
-            echo "also make sure versionNumber is correct!"
-            usage
-        fi
+    compile|test|package|publishLocal|publishSigned)
         CMD="$1";;
     *) echo "unknown argument: $1"; usage;;
 esac


### PR DESCRIPTION
Hey Erik,

The release script looks sharp.  The only thing I can think of was making the script handle toggling the `isRelease` value.  There's a benefit to the manual step that you had, but it's possible to automate it.  No hard feelings if you want to keep the manual step.