### PR TITLE
Update Scala.js 0.6.29 in release script

### DIFF
--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -2,11 +2,13 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
+// Update SCALAJS_VERSION in release.sh, as well
 val scalaJSVersion =
   Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.29")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
+// Update SCALANATIVE_VERSION in release.sh, as well
 val scalaNativeVersion =
   Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.3.9")
 

--- a/release.sh
+++ b/release.sh
@@ -63,7 +63,7 @@ runsbt "+ clean"
 runsbt "+ jvm/$CMD"
 
 # step 4b: js releases (clean versions)
-SCALAJS_VERSION="0.6.28" runsbt "+ js/$CMD"
+SCALAJS_VERSION="0.6.29" runsbt "+ js/$CMD"
 runsbt "+ js/clean"
 SCALAJS_VERSION="1.0.0-M8" runsbt "+ js/$CMD"
 


### PR DESCRIPTION
This is the alternative to #549.