### PR TITLE
Validate ScalaJS and Scala Native versions in plugins.sbt.

### DIFF
--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -2,15 +2,29 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
+def env(name: String): Option[String] =
+  Option(System.getenv(name))
+
+def printAndDie(msg: String): Nothing = {
+  println(msg)
+  sys.error(msg)
+}
+
 // Update SCALAJS_VERSION in release.sh, as well
-val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.29")
+val scalaJSVersion = env("SCALAJS_VERSION") match {
+  case Some("0.6.29") | None => "0.6.29"
+  case Some("1.0.0-M8") => "1.0.0-M8"
+  case Some(v) => printAndDie(s"unsupported scala.js version: $v")
+}
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 // Update SCALANATIVE_VERSION in release.sh, as well
-val scalaNativeVersion =
-  Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.3.9")
+val scalaNativeVersion = env("SCALANATIVE_VERSION") match {
+  case Some("0.3.9") | None => "0.3.9"
+  case Some("0.4.0-M2") => "0.4.0-M2"
+  case Some(v) => printAndDie(s"unsupported scala native version: $v")
+}
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeVersion)
 


### PR DESCRIPTION
Since we pass explicit versions in release.sh, it's important to make sure it
doesn't get out of sync with our definitions in plugins.sbt. To that end, this
commit ensures that we get one of two exact versions we're prepared to support.
Otherwise, we'll throw an error during SBT initialization.

This makes it slightly more annoying to test ScalaCheck with a new version of
one of these plugins (you have to modify plugins.sbt as opposed to just passing
a new variable on the command line) but also means we'll never accidentally
release with the wrong version.

I ended up printing before throwing an error because SBT doesn't display the
actual exception (and message) unless you type (l)ast. This way, you'll always
see the message (which should make it pretty obvious what the mistake was).