### PR TITLE
Re-enable snapshot releases?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ env:
     - PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=false
     - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false
     - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-M8
+    - PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=true
+    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
+    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0-M8
 sudo: false
 
 before_cache:
@@ -69,15 +72,35 @@ matrix:
       - cd scalafix
       - sbt tests/test
   exclude:
+    - jdk: oraclejdk8
+      env: PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=false
+    - jdk: oraclejdk8
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false
+    - jdk: oraclejdk8
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-M8
+    - jdk: openjdk11
+      env: PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=true
+    - jdk: openjdk11
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
+    - jdk: openjdk11
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0-M8
     - scala: 2.10.7
       env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-M8
+    - scala: 2.10.7
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0-M8
     - scala: 2.11.12
       env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-M8
+    - scala: 2.11.12
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0-M8
     - jdk: openjdk11
       scala: 2.10.7
     - jdk: openjdk11
       env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false
     - jdk: openjdk11
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
+    - jdk: openjdk11
       env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-M8
+    - jdk: openjdk11
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0-M8
     - jdk: openjdk11
       scala: 2.11.12

--- a/build.sbt
+++ b/build.sbt
@@ -114,6 +114,13 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
     else Set("org.scalacheck" %%% "scalacheck" % "1.14.0")
   },
 
+  /* Snapshots are published after successful merges to master.
+   * Available with the following sbt snippet:
+   * resolvers +=
+   *   "Sonatype OSS Snapshots" at
+   *   "https://oss.sonatype.org/content/repositories/snapshots",
+   * libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.1-7ad5373-SNAPSHOT" % "test",
+   */
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     val (name, path) = if (isSnapshot.value) ("snapshots", "content/repositories/snapshots")


### PR DESCRIPTION
Erik pointed out to me that snapshots can be published to Sonatype.  Any interest in re-enabling this?  It may be useful for 1.15 development.  I think it might have been accidentally disabled during Travis cleanup.

Humorously, it was still occuring for just Scala Native:

https://oss.sonatype.org/content/repositories/snapshots/org/scalacheck/scalacheck_native0.3_2.11/