### PR TITLE
Partial revert of ff83d14

### DIFF
--- a/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
+++ b/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
@@ -28,7 +28,11 @@ private abstract class ScalaCheckRunner extends Runner {
 
   def deserializeTask(task: String, deserializer: String => TaskDef): BaseTask = {
     val taskDef = deserializer(task)
-    if (taskDef.selectors.isEmpty) rootTask(taskDef)
+    val countTestSelectors = taskDef.selectors.toSeq.count {
+      case _:TestSelector => true
+      case _ => false
+    }
+    if (countTestSelectors == 0) rootTask(taskDef)
     else checkPropTask(taskDef, single = true)
   }
 


### PR DESCRIPTION
I'm not familiar with this portion of the code base, so I'm not sure what the consequence of reverting this, but this change causes Scala.js tests to run again.
