### PR TITLE
Clean up the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: scala
-dist: trusty
 script: ./tools/travis-script.sh
 after_success: ./tools/travis-deploy.sh
 branches:
   only:
     - master
-    - 1.12.x
-    - 1.13.x
     - 1.14.x
+    - 1.15.x
 notifications:
   email:
     - rickynils@gmail.com
@@ -19,7 +17,7 @@ scala:
   - 2.12.10
   - 2.13.1
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 env:
   global:
@@ -50,18 +48,10 @@ matrix:
     - scala: 2.11.12
       before_script:
         - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
-      sudo: required
-      addons:
-        apt:
-          update: true # https://github.com/typelevel/scalacheck/issues/412
       env: PLATFORM=native SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
     - scala: 2.11.12
       before_script:
         - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
-      sudo: required
-      addons:
-        apt:
-          update: true # https://github.com/rickynils/scalacheck/issues/412
       env: PLATFORM=native SBT_PARALLEL=true SCALANATIVE_VERSION="0.4.0-M2" WORKERS=1 DEPLOY=true
     - env: EXAMPLES
       script:
@@ -72,11 +62,11 @@ matrix:
       - cd scalafix
       - sbt tests/test
   exclude:
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       env: PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=false
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-M8
     - jdk: openjdk11
       env: PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=true

--- a/build.sbt
+++ b/build.sbt
@@ -80,8 +80,6 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
 
   resolvers += "sonatype" at "https://oss.sonatype.org/content/repositories/releases",
 
-  javacOptions += "-Xmx1024M",
-
   // 2.10 - 2.13
   scalacOptions ++= {
     def mk(r: Range)(strs: String*): Int => Seq[String] =
@@ -141,18 +139,20 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
 
   pomIncludeRepository := { _ => false },
 
-  pomExtra := {
-    <scm>
-      <url>https://github.com/typelevel/scalacheck</url>
-      <connection>scm:git:git@github.com:typelevel/scalacheck.git</connection>
-    </scm>
-    <developers>
-      <developer>
-        <id>rickynils</id>
-        <name>Rickard Nilsson</name>
-      </developer>
-    </developers>
-  }
+  scmInfo := Some(
+    ScmInfo(
+      url("https://github.com/typelevel/scalacheck"),
+      "scm:git:git@github.com:typelevel/scalacheck.git"
+    )
+  ),
+  developers := List(
+    Developer(
+      id    = "rickynils",
+      name  = "Rickard Nilsson",
+      email = "rickynils@gmail.com",
+      url   = url("https://github.com/rickynils")
+    )
+  )
 )
 
 lazy val js = project.in(file("js"))
@@ -171,7 +171,11 @@ lazy val js = project.in(file("js"))
 lazy val jvm = project.in(file("jvm"))
   .settings(sharedSettings: _*)
   .settings(
-    fork in Test := true,
+    fork in Test := {
+      // Serialization issue in 2.13
+      scalaMajorVersion.value == 13 // ==> true
+      // else ==> false
+    },
     libraryDependencies += "org.scala-sbt" %  "test-interface" % "1.0"
   )
 

--- a/examples/commands-leveldb/build.sbt
+++ b/examples/commands-leveldb/build.sbt
@@ -14,7 +14,5 @@ libraryDependencies ++= Seq(
 //  "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.1"
 )
 
-javacOptions ++= Seq("-Xmx1024M")
-
 // JNI workaround, http://stackoverflow.com/questions/19425613/unsatisfiedlinkerror-with-native-library-under-sbt
 fork := true

--- a/examples/commands-nix/build.sbt
+++ b/examples/commands-nix/build.sbt
@@ -6,5 +6,3 @@ libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % "1.14.1",
   "net.java.dev.jna" % "jna" % "4.5.1"
 )
-
-javacOptions ++= Seq("-Xmx1024M")

--- a/examples/scalajs/build.sbt
+++ b/examples/scalajs/build.sbt
@@ -6,6 +6,4 @@ version := "0.1-SNAPSHOT"
 
 scalaVersion := "2.12.10"
 
-javacOptions += "-Xmx2048M"
-
 libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.14.1" % "test"

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -27,5 +27,3 @@ val scalaNativeVersion = env("SCALANATIVE_VERSION") match {
 }
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeVersion)
-
-scalacOptions += "-deprecation"


### PR DESCRIPTION
- Drop explicit memory settings for JVM
- Only fork JVM in sbt with Scala 2.13
- Switch to Xenial in Travis
- Switch to OpenJDK for Java 8 in Travis
- Update `pomExtra` in sbt to new syntax
- Remove errant `scalacOptions` in `plugins.sbt`.