### PR TITLE
Force posNum and negNum generators to always return values

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,9 @@
 # ScalaCheck CHANGELOG
 
+### Changed
+
+* Force posNum and negNum to retry if they produce an illegal value and otherwise would produce None, since 1.14.1.
+
 ## 1.14.2 (2019-09-25)
 
 * Binary compatible with 1.14.1 version of ScalaCheck.

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,8 +1,9 @@
 # ScalaCheck CHANGELOG
 
-### Changed
+### Fixed
 
-* Force posNum and negNum to retry if they produce an illegal value and otherwise would produce None, since 1.14.1.
+* Ensure posNum and negNum always return values
+  [#568](https://github.com/typelevel/scalacheck/issues/568)
 
 ## 1.14.2 (2019-09-25)
 

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -871,7 +871,7 @@ object Gen extends GenArities with GenVersionSpecific {
 
   /** Generates negative numbers of uniform distribution, with an
    *  lower bound of the negated generation size parameter. */
-  def negNum[T](implicit num: Numeric[T], c: Choose[T]): Gen[T] = posNum[T].map(num.negate(_))
+  def negNum[T](implicit num: Numeric[T], c: Choose[T]): Gen[T] = posNum.map(num.negate _)
 
   /** Generates numbers within the given inclusive range, with
    *  extra weight on zero, +/- unity, both extremities, and any special

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -863,15 +863,15 @@ object Gen extends GenArities with GenVersionSpecific {
    *  upper bound of the generation size parameter. */
   def posNum[T](implicit num: Numeric[T], c: Choose[T]): Gen[T] = {
     import num._
-    sized(n => c.choose(zero, max(fromInt(n), one)).retryUntil(_ != zero))
+    num match {
+      case _: Fractional[_] => sized(n => c.choose(zero, max(fromInt(n), one)).suchThat(_ != zero))
+      case _ => sized(n => c.choose(one, max(fromInt(n), one)))
+    }
   }
 
   /** Generates negative numbers of uniform distribution, with an
    *  lower bound of the negated generation size parameter. */
-  def negNum[T](implicit num: Numeric[T], c: Choose[T]): Gen[T] = {
-    import num._
-    sized(n => c.choose(min(-fromInt(n), -one), zero).retryUntil(_ != zero))
-  }
+  def negNum[T](implicit num: Numeric[T], c: Choose[T]): Gen[T] = posNum[T].map(num.negate(_))
 
   /** Generates numbers within the given inclusive range, with
    *  extra weight on zero, +/- unity, both extremities, and any special

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -863,14 +863,14 @@ object Gen extends GenArities with GenVersionSpecific {
    *  upper bound of the generation size parameter. */
   def posNum[T](implicit num: Numeric[T], c: Choose[T]): Gen[T] = {
     import num._
-    sized(n => c.choose(zero, max(fromInt(n), one)).suchThat(_ != zero))
+    sized(n => c.choose(zero, max(fromInt(n), one)).retryUntil(_ != zero))
   }
 
   /** Generates negative numbers of uniform distribution, with an
    *  lower bound of the negated generation size parameter. */
   def negNum[T](implicit num: Numeric[T], c: Choose[T]): Gen[T] = {
     import num._
-    sized(n => c.choose(min(-fromInt(n), -one), zero).suchThat(_ != zero))
+    sized(n => c.choose(min(-fromInt(n), -one), zero).retryUntil(_ != zero))
   }
 
   /** Generates numbers within the given inclusive range, with


### PR DESCRIPTION
Fixes (part of) #568.