### PR TITLE
Various Gen refactors for better performance.

### DIFF
--- a/bench/src/main/scala/org/scalacheck/bench/GenBench.scala
+++ b/bench/src/main/scala/org/scalacheck/bench/GenBench.scala
@@ -3,6 +3,7 @@ package org.scalacheck.bench
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalacheck.rng.Seed
 
@@ -110,6 +111,10 @@ class GenBench {
   def asciiPrintableStr(): List[String] =
     seeds.map(s => Gen.asciiPrintableStr.pureApply(params, s))
 
+  @Benchmark
+  def arbitraryString(): List[String] =
+    seeds.map(s => arbitrary[String].pureApply(params, s))
+
   private val gens = Vector.fill(10)(genInt)
 
   @Benchmark
@@ -145,5 +150,13 @@ class GenBench {
       val g = Gen.listOf(genInt)
       val gf = Gen.frequency(1 -> g, 2 -> g, 3 -> g, 4 -> g, 5 -> g)
       gf.pureApply(params, s)
+    }
+
+  private def fg = Gen.choose(1, 100).filter(_ >= 3)
+
+  @Benchmark
+  def testFilter(): List[List[Int]] =
+    seeds.map { s =>
+      Gen.listOfN(100, fg).pureApply(params, s)
     }
 }

--- a/project/codegen.scala
+++ b/project/codegen.scala
@@ -84,20 +84,13 @@ object codegen {
   
   def zip(i: Int) = {
     val gens = flatMappedGenerators(i, idents("t",i) zip idents("g",i))
-  
-    def sieveCopy = idents("g",i) zip idents("t",i) map { case (g,t) => s"$g.sieveCopy($t)" } mkString " && "
     s"""
         |  /** Combines the given generators into one generator that produces a
         |   *  tuple of their generated values. */
         |  def zip[${types(i)}](
         |    ${wrappedArgs("Gen",i)}
-        |  ): Gen[(${types(i)})] = {
-        |    val g = $gens
-        |    g.suchThat {
-        |      case (${vals(i)}) =>
-        |        ${sieveCopy}
-        |    }
-        |  }
+        |  ): Gen[(${types(i)})] =
+        |    $gens
         |""".stripMargin
   }
   

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -81,21 +81,21 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   /**** Arbitrary instances for each AnyVal ****/
 
   /** Arbitrary instance of Boolean */
-  implicit val arbBool: Arbitrary[Boolean] =
+  implicit lazy val arbBool: Arbitrary[Boolean] =
     Arbitrary(oneOf(true, false))
 
   /** Arbitrary instance of Int */
-  implicit val arbInt: Arbitrary[Int] = Arbitrary(
+  implicit lazy val arbInt: Arbitrary[Int] = Arbitrary(
     Gen.chooseNum(Int.MinValue, Int.MaxValue)
   )
 
   /** Arbitrary instance of Long */
-  implicit val arbLong: Arbitrary[Long] = Arbitrary(
+  implicit lazy val arbLong: Arbitrary[Long] = Arbitrary(
     Gen.chooseNum(Long.MinValue, Long.MaxValue)
   )
 
   /** Arbitrary instance of Float */
-  implicit val arbFloat: Arbitrary[Float] = Arbitrary(
+  implicit lazy val arbFloat: Arbitrary[Float] = Arbitrary(
     for {
       s <- choose(0, 1)
       e <- choose(0, 0xfe)
@@ -104,7 +104,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   )
 
   /** Arbitrary instance of Double */
-  implicit val arbDouble: Arbitrary[Double] = Arbitrary(
+  implicit lazy val arbDouble: Arbitrary[Double] = Arbitrary(
     for {
       s <- choose(0L, 1L)
       e <- choose(0L, 0x7feL)
@@ -113,23 +113,23 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   )
 
   /** Arbitrary instance of Char */
-  implicit val arbChar: Arbitrary[Char] =
+  implicit lazy val arbChar: Arbitrary[Char] =
     Arbitrary(Gen.unicodeChar)
 
   /** Arbitrary instance of Byte */
-  implicit val arbByte: Arbitrary[Byte] =
+  implicit lazy val arbByte: Arbitrary[Byte] =
     Arbitrary(Gen.chooseNum(Byte.MinValue, Byte.MaxValue))
 
   /** Arbitrary instance of Short */
-  implicit val arbShort: Arbitrary[Short] =
+  implicit lazy val arbShort: Arbitrary[Short] =
     Arbitrary(Gen.chooseNum(Short.MinValue, Short.MaxValue))
 
   /** Absolutely, totally, 100% arbitrarily chosen Unit. */
-  implicit val arbUnit: Arbitrary[Unit] =
+  implicit lazy val arbUnit: Arbitrary[Unit] =
     Arbitrary(Gen.const(()))
 
   /** Arbitrary AnyVal */
-  implicit val arbAnyVal: Arbitrary[AnyVal] = Arbitrary(oneOf(
+  implicit lazy val arbAnyVal: Arbitrary[AnyVal] = Arbitrary(oneOf(
     arbitrary[Unit], arbitrary[Boolean], arbitrary[Char], arbitrary[Byte],
     arbitrary[Short], arbitrary[Int], arbitrary[Long], arbitrary[Float],
     arbitrary[Double]
@@ -138,35 +138,35 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   /**** Arbitrary instances of other common types ****/
 
   /** Arbitrary instance of String */
-  implicit val arbString: Arbitrary[String] =
+  implicit lazy val arbString: Arbitrary[String] =
     Arbitrary(Gen.unicodeStr)
 
   /** Arbitrary instance of Date */
-  implicit val arbDate: Arbitrary[java.util.Date] =
+  implicit lazy val arbDate: Arbitrary[java.util.Date] =
     Arbitrary(Gen.calendar.map(_.getTime))
 
   /** Arbitrary instance of Calendar */
-  implicit val arbCalendar: Arbitrary[java.util.Calendar] =
+  implicit lazy val arbCalendar: Arbitrary[java.util.Calendar] =
     Arbitrary(Gen.calendar)
 
   /** Arbitrary instance of Throwable */
-  implicit val arbThrowable: Arbitrary[Throwable] =
+  implicit lazy val arbThrowable: Arbitrary[Throwable] =
     Arbitrary(oneOf(const(new Exception), const(new Error)))
 
   /** Arbitrary instance of Exception */
-  implicit val arbException: Arbitrary[Exception] =
+  implicit lazy val arbException: Arbitrary[Exception] =
     Arbitrary(const(new Exception))
 
   /** Arbitrary instance of Error */
-  implicit val arbError: Arbitrary[Error] =
+  implicit lazy val arbError: Arbitrary[Error] =
     Arbitrary(const(new Error))
 
   /** Arbitrary instance of UUID */
-  implicit val arbUuid: Arbitrary[java.util.UUID] =
+  implicit lazy val arbUuid: Arbitrary[java.util.UUID] =
     Arbitrary(Gen.uuid)
 
   /** Arbitrary BigInt */
-  implicit val arbBigInt: Arbitrary[BigInt] = {
+  implicit lazy val arbBigInt: Arbitrary[BigInt] = {
     val long: Gen[Long] =
       Gen.choose(Long.MinValue, Long.MaxValue).map(x => if (x == 0) 1L else x)
 
@@ -191,7 +191,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   }
 
   /** Arbitrary BigDecimal */
-  implicit val arbBigDecimal: Arbitrary[BigDecimal] = {
+  implicit lazy val arbBigDecimal: Arbitrary[BigDecimal] = {
     import java.math.MathContext, MathContext._
 
     val genMathContext0: Gen[MathContext] =
@@ -243,7 +243,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   }
 
   /** Arbitrary java.lang.Number */
-  implicit val arbNumber: Arbitrary[Number] = {
+  implicit lazy val arbNumber: Arbitrary[Number] = {
     val gen = Gen.oneOf(
       arbitrary[Byte], arbitrary[Short], arbitrary[Int], arbitrary[Long],
       arbitrary[Float], arbitrary[Double]
@@ -254,7 +254,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   }
 
   /** Arbitrary instance of FiniteDuration */
-  implicit val arbFiniteDuration: Arbitrary[FiniteDuration] =
+  implicit lazy val arbFiniteDuration: Arbitrary[FiniteDuration] =
     Arbitrary(Gen.finiteDuration)
 
   /**
@@ -263,11 +263,11 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
    * In addition to `FiniteDuration` values, this can generate `Duration.Inf`,
    * `Duration.MinusInf`, and `Duration.Undefined`.
    */
-  implicit val arbDuration: Arbitrary[Duration] =
+  implicit lazy val arbDuration: Arbitrary[Duration] =
     Arbitrary(Gen.duration)
 
   /** Generates an arbitrary property */
-  implicit val arbProp: Arbitrary[Prop] = {
+  implicit lazy val arbProp: Arbitrary[Prop] = {
     import Prop._
     val undecidedOrPassed = forAll { b: Boolean =>
       b ==> true
@@ -283,7 +283,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   }
 
   /** Arbitrary instance of test parameters */
-  implicit val arbTestParameters: Arbitrary[Test.Parameters] =
+  implicit lazy val arbTestParameters: Arbitrary[Test.Parameters] =
     Arbitrary(for {
       _minSuccTests <- choose(10,200)
       _maxDiscardRatio <- choose(0.2f,10f)
@@ -300,7 +300,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
     )
 
   /** Arbitrary instance of gen params */
-  implicit val arbGenParams: Arbitrary[Gen.Parameters] =
+  implicit lazy val arbGenParams: Arbitrary[Gen.Parameters] =
     Arbitrary(for {
       sz <- arbitrary[Int] suchThat (_ >= 0)
     } yield Gen.Parameters.default.withSize(sz))
@@ -309,7 +309,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   // Specialised collections //
 
   /** Arbitrary instance of scala.collection.BitSet */
-  implicit val arbBitSet: Arbitrary[collection.BitSet] = Arbitrary(
+  implicit lazy val arbBitSet: Arbitrary[collection.BitSet] = Arbitrary(
     buildableOf[collection.BitSet,Int](sized(sz => choose(0,sz)))
   )
 

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -80,29 +80,22 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
 
   /**** Arbitrary instances for each AnyVal ****/
 
-  /** Arbitrary AnyVal */
-  implicit lazy val arbAnyVal: Arbitrary[AnyVal] = Arbitrary(oneOf(
-    arbitrary[Unit], arbitrary[Boolean], arbitrary[Char], arbitrary[Byte],
-    arbitrary[Short], arbitrary[Int], arbitrary[Long], arbitrary[Float],
-    arbitrary[Double]
-  ))
-
   /** Arbitrary instance of Boolean */
-  implicit lazy val arbBool: Arbitrary[Boolean] =
+  implicit val arbBool: Arbitrary[Boolean] =
     Arbitrary(oneOf(true, false))
 
   /** Arbitrary instance of Int */
-  implicit lazy val arbInt: Arbitrary[Int] = Arbitrary(
+  implicit val arbInt: Arbitrary[Int] = Arbitrary(
     Gen.chooseNum(Int.MinValue, Int.MaxValue)
   )
 
   /** Arbitrary instance of Long */
-  implicit lazy val arbLong: Arbitrary[Long] = Arbitrary(
+  implicit val arbLong: Arbitrary[Long] = Arbitrary(
     Gen.chooseNum(Long.MinValue, Long.MaxValue)
   )
 
   /** Arbitrary instance of Float */
-  implicit lazy val arbFloat: Arbitrary[Float] = Arbitrary(
+  implicit val arbFloat: Arbitrary[Float] = Arbitrary(
     for {
       s <- choose(0, 1)
       e <- choose(0, 0xfe)
@@ -111,7 +104,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   )
 
   /** Arbitrary instance of Double */
-  implicit lazy val arbDouble: Arbitrary[Double] = Arbitrary(
+  implicit val arbDouble: Arbitrary[Double] = Arbitrary(
     for {
       s <- choose(0L, 1L)
       e <- choose(0L, 0x7feL)
@@ -120,53 +113,60 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   )
 
   /** Arbitrary instance of Char */
-  implicit lazy val arbChar: Arbitrary[Char] =
+  implicit val arbChar: Arbitrary[Char] =
     Arbitrary(Gen.unicodeChar)
 
   /** Arbitrary instance of Byte */
-  implicit lazy val arbByte: Arbitrary[Byte] =
+  implicit val arbByte: Arbitrary[Byte] =
     Arbitrary(Gen.chooseNum(Byte.MinValue, Byte.MaxValue))
 
   /** Arbitrary instance of Short */
-  implicit lazy val arbShort: Arbitrary[Short] =
+  implicit val arbShort: Arbitrary[Short] =
     Arbitrary(Gen.chooseNum(Short.MinValue, Short.MaxValue))
 
   /** Absolutely, totally, 100% arbitrarily chosen Unit. */
-  implicit lazy val arbUnit: Arbitrary[Unit] =
+  implicit val arbUnit: Arbitrary[Unit] =
     Arbitrary(Gen.const(()))
+
+  /** Arbitrary AnyVal */
+  implicit val arbAnyVal: Arbitrary[AnyVal] = Arbitrary(oneOf(
+    arbitrary[Unit], arbitrary[Boolean], arbitrary[Char], arbitrary[Byte],
+    arbitrary[Short], arbitrary[Int], arbitrary[Long], arbitrary[Float],
+    arbitrary[Double]
+  ))
 
   /**** Arbitrary instances of other common types ****/
 
   /** Arbitrary instance of String */
-  implicit lazy val arbString: Arbitrary[String] =
+  implicit val arbString: Arbitrary[String] =
     Arbitrary(Gen.unicodeStr)
 
   /** Arbitrary instance of Date */
-  implicit lazy val arbDate: Arbitrary[java.util.Date] =
+  implicit val arbDate: Arbitrary[java.util.Date] =
     Arbitrary(Gen.calendar.map(_.getTime))
 
   /** Arbitrary instance of Calendar */
-  implicit lazy val arbCalendar: Arbitrary[java.util.Calendar] =
+  implicit val arbCalendar: Arbitrary[java.util.Calendar] =
     Arbitrary(Gen.calendar)
 
   /** Arbitrary instance of Throwable */
-  implicit lazy val arbThrowable: Arbitrary[Throwable] =
+  implicit val arbThrowable: Arbitrary[Throwable] =
     Arbitrary(oneOf(const(new Exception), const(new Error)))
 
   /** Arbitrary instance of Exception */
-  implicit lazy val arbException: Arbitrary[Exception] =
+  implicit val arbException: Arbitrary[Exception] =
     Arbitrary(const(new Exception))
 
   /** Arbitrary instance of Error */
-  implicit lazy val arbError: Arbitrary[Error] =
+  implicit val arbError: Arbitrary[Error] =
     Arbitrary(const(new Error))
 
   /** Arbitrary instance of UUID */
-  implicit lazy val arbUuid: Arbitrary[java.util.UUID] =
+  implicit val arbUuid: Arbitrary[java.util.UUID] =
     Arbitrary(Gen.uuid)
 
   /** Arbitrary BigInt */
-  implicit lazy val arbBigInt: Arbitrary[BigInt] = {
+  implicit val arbBigInt: Arbitrary[BigInt] = {
     val long: Gen[Long] =
       Gen.choose(Long.MinValue, Long.MaxValue).map(x => if (x == 0) 1L else x)
 
@@ -191,7 +191,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   }
 
   /** Arbitrary BigDecimal */
-  implicit lazy val arbBigDecimal: Arbitrary[BigDecimal] = {
+  implicit val arbBigDecimal: Arbitrary[BigDecimal] = {
     import java.math.MathContext, MathContext._
 
     val genMathContext0: Gen[MathContext] =
@@ -243,7 +243,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   }
 
   /** Arbitrary java.lang.Number */
-  implicit lazy val arbNumber: Arbitrary[Number] = {
+  implicit val arbNumber: Arbitrary[Number] = {
     val gen = Gen.oneOf(
       arbitrary[Byte], arbitrary[Short], arbitrary[Int], arbitrary[Long],
       arbitrary[Float], arbitrary[Double]
@@ -254,7 +254,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   }
 
   /** Arbitrary instance of FiniteDuration */
-  implicit lazy val arbFiniteDuration: Arbitrary[FiniteDuration] =
+  implicit val arbFiniteDuration: Arbitrary[FiniteDuration] =
     Arbitrary(Gen.finiteDuration)
 
   /**
@@ -263,11 +263,11 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
    * In addition to `FiniteDuration` values, this can generate `Duration.Inf`,
    * `Duration.MinusInf`, and `Duration.Undefined`.
    */
-  implicit lazy val arbDuration: Arbitrary[Duration] =
+  implicit val arbDuration: Arbitrary[Duration] =
     Arbitrary(Gen.duration)
 
   /** Generates an arbitrary property */
-  implicit lazy val arbProp: Arbitrary[Prop] = {
+  implicit val arbProp: Arbitrary[Prop] = {
     import Prop._
     val undecidedOrPassed = forAll { b: Boolean =>
       b ==> true
@@ -283,7 +283,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   }
 
   /** Arbitrary instance of test parameters */
-  implicit lazy val arbTestParameters: Arbitrary[Test.Parameters] =
+  implicit val arbTestParameters: Arbitrary[Test.Parameters] =
     Arbitrary(for {
       _minSuccTests <- choose(10,200)
       _maxDiscardRatio <- choose(0.2f,10f)
@@ -300,7 +300,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
     )
 
   /** Arbitrary instance of gen params */
-  implicit lazy val arbGenParams: Arbitrary[Gen.Parameters] =
+  implicit val arbGenParams: Arbitrary[Gen.Parameters] =
     Arbitrary(for {
       sz <- arbitrary[Int] suchThat (_ >= 0)
     } yield Gen.Parameters.default.withSize(sz))
@@ -309,7 +309,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   // Specialised collections //
 
   /** Arbitrary instance of scala.collection.BitSet */
-  implicit lazy val arbBitSet: Arbitrary[collection.BitSet] = Arbitrary(
+  implicit val arbBitSet: Arbitrary[collection.BitSet] = Arbitrary(
     buildableOf[collection.BitSet,Int](sized(sz => choose(0,sz)))
   )
 

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -120,37 +120,26 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   )
 
   /** Arbitrary instance of Char */
-  implicit lazy val arbChar: Arbitrary[Char] = Arbitrary {
-    // exclude 0xFFFE due to this bug: https://bit.ly/2pTpAu8
-    // also exclude 0xFFFF as it is not unicode: http://bit.ly/2cVBrzK
-    val validRangesInclusive = List[(Char, Char)](
-      (0x0000, 0xD7FF),
-      (0xE000, 0xFFFD)
-    )
-
-    Gen.frequency((validRangesInclusive.map {
-      case (first, last) => (last + 1 - first, Gen.choose[Char](first, last))
-    }: List[(Int, Gen[Char])]): _*)
-  }
+  implicit lazy val arbChar: Arbitrary[Char] =
+    Arbitrary(Gen.unicodeChar)
 
   /** Arbitrary instance of Byte */
-  implicit lazy val arbByte: Arbitrary[Byte] = Arbitrary(
-    Gen.chooseNum(Byte.MinValue, Byte.MaxValue)
-  )
+  implicit lazy val arbByte: Arbitrary[Byte] =
+    Arbitrary(Gen.chooseNum(Byte.MinValue, Byte.MaxValue))
 
   /** Arbitrary instance of Short */
-  implicit lazy val arbShort: Arbitrary[Short] = Arbitrary(
-    Gen.chooseNum(Short.MinValue, Short.MaxValue)
-  )
+  implicit lazy val arbShort: Arbitrary[Short] =
+    Arbitrary(Gen.chooseNum(Short.MinValue, Short.MaxValue))
 
   /** Absolutely, totally, 100% arbitrarily chosen Unit. */
-  implicit lazy val arbUnit: Arbitrary[Unit] = Arbitrary(const(()))
+  implicit lazy val arbUnit: Arbitrary[Unit] =
+    Arbitrary(Gen.const(()))
 
   /**** Arbitrary instances of other common types ****/
 
   /** Arbitrary instance of String */
   implicit lazy val arbString: Arbitrary[String] =
-    Arbitrary(arbitrary[List[Char]] map (_.mkString))
+    Arbitrary(Gen.unicodeStr)
 
   /** Arbitrary instance of Date */
   implicit lazy val arbDate: Arbitrary[java.util.Date] =

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -237,7 +237,7 @@ object Gen extends GenArities with GenVersionSpecific {
           r(None, seed).copy(l = labels)
         case Some(t) =>
           val r = f(t)
-          r.copy(l = labels ++ r.labels, sd = r.seed)
+          r.copy(l = labels | r.labels, sd = r.seed)
       }
   }
 
@@ -626,25 +626,27 @@ object Gen extends GenArities with GenVersionSpecific {
     evb: Buildable[T,C], evt: C => Traversable[T]
   ): Gen[C] = {
     require(n >= 0, s"invalid size given: $n")
-    gen { (p, seed0) =>
-      var seed: Seed = seed0
-      val bldr = evb.builder
-      val allowedFailures = Integer.max(10, n / 10)
-      var failures = 0
-      var count = 0
-      while (count < n && failures < allowedFailures) {
-        val gres = g.doApply(p, seed)
-        gres.retrieve match {
-          case Some(t) =>
-            bldr += t
-            count += 1
-          case None =>
-            failures += 1
+    new Gen[C] {
+      def doApply(p: P, seed0: Seed): R[C] = {
+        var seed: Seed = seed0
+        val bldr = evb.builder
+        val allowedFailures = Gen.collectionRetries(n)
+        var failures = 0
+        var count = 0
+        while (count < n) {
+          val res = g.doApply(p, seed)
+          res.retrieve match {
+            case Some(t) =>
+              bldr += t
+              count += 1
+            case None =>
+              failures += 1
+              if (failures >= allowedFailures) return r(None, res.seed)
+          }
+          seed = res.seed
         }
-        seed = gres.seed
+        r(Some(bldr.result), seed)
       }
-      val res = if (count == n) Some(bldr.result) else None
-      r(res, seed)
     }
   }
 
@@ -711,20 +713,27 @@ object Gen extends GenArities with GenVersionSpecific {
    *  is equal to calling <code>containerOfN[Map,(T,U)](n,g)</code>. */
   def mapOfN[T,U](n: Int, g: Gen[(T, U)]) = buildableOfN[Map[T, U],(T, U)](n, g)
 
-  /** Generates an infinite stream. */
+  /**
+   * Generates an infinite stream.
+   *
+   * Failures in the underlying generator may terminate the stream.
+   * Otherwise it will continue forever.
+   */
   def infiniteStream[T](g: => Gen[T]): Gen[Stream[T]] = {
-    def unfold(p: P, seed: Seed): Stream[T] = {
-      val r = g.doPureApply(p, seed)
-      r.retrieve match {
-        case Some(t) => t #:: unfold(p, r.seed)
-        case None => Stream.empty
+    val attemptsPerItem = 10
+    def unfold(p: P, seed: Seed, attemptsLeft: Int): Stream[T] =
+      if (attemptsLeft <= 0) {
+        Stream.empty
+      } else {
+        val r = g.doPureApply(p, seed)
+        r.retrieve match {
+          case Some(t) => t #:: unfold(p, r.seed, attemptsPerItem)
+          case None => unfold(p, r.seed, attemptsLeft - 1)
+        }
       }
-    }
     gen { (p, seed0) =>
-      new R[Stream[T]] {
-        val result: Option[Stream[T]] = Some(unfold(p, seed0))
-        val seed: Seed = seed0.slide
-      }
+      val stream = unfold(p, seed0, attemptsPerItem)
+      r(Some(stream), seed0.slide)
     }
   }
 
@@ -765,7 +774,7 @@ object Gen extends GenArities with GenVersionSpecific {
           buf += t
         } else {
           val (x, s) = seed.long
-          val i = (x & 0x7fffffff).toInt % count
+          val i = (x & Long.MaxValue % count).toInt
           if (i < n) buf(i) = t
           seed = s
         }
@@ -848,19 +857,25 @@ object Gen extends GenArities with GenVersionSpecific {
 
   //// String Generators ////
 
-  @tailrec private def mkString(n: Int, sb: StringBuilder, gc: Gen[Char], p: P, seed0: Seed): R[String] =
-    if (n <= 0) {
-      r(Some(sb.toString), seed0)
-    } else {
-      val res = gc.doApply(p, seed0)
+  private def mkString(n: Int, sb: StringBuilder, gc: Gen[Char], p: P, seed0: Seed): R[String] = {
+    var seed: Seed = seed0
+    val allowedFailures = Gen.collectionRetries(n)
+    var failures = 0
+    var count = 0
+    while (count < n) {
+      val res = gc.doApply(p, seed)
       res.retrieve match {
         case Some(c) =>
           sb += c
+          count += 1
         case None =>
-          ()
+          failures += 1
+          if (failures >= allowedFailures) return r(None, res.seed)
       }
-      mkString(n - 1, sb, gc, p, res.seed)
+      seed = res.seed
     }
+    r(Some(sb.toString), seed)
+  }
 
   def stringOfN(n: Int, gc: Gen[Char]): Gen[String] =
     gen { (p, seed) =>
@@ -1058,9 +1073,14 @@ object Gen extends GenArities with GenVersionSpecific {
     1 -> const(Duration.Zero),
     6 -> finiteDuration)
 
+  // used to compute a uniformly-distributed size
   private def mkSize(p: Gen.Parameters, seed0: Seed): (Int, Seed) = {
     val maxSize = Integer.max(p.size + 1, 1)
     val (x, seed1) = seed0.long
-    ((x % maxSize).toInt, seed1)
+    (((x & Long.MaxValue) % maxSize).toInt, seed1)
   }
+
+  // used to calculate how many per-item retries we should allow.
+  private def collectionRetries(n: Int): Int =
+    Integer.max(10, n / 10)
 }

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -779,7 +779,7 @@ object Prop {
     }
 
     def shrinker(x: T, r: Result, shrinks: Int, orig: T): Result = {
-      val xs = shrink(x).filter(gr.sieve)
+      val xs = shrink(x)
       val res = r.addArg(Arg(labels,x,shrinks,orig,pp(x),pp(orig)))
       if(xs.isEmpty) res else getFirstFailure(xs) match {
         case Right((x2,r2)) => res

--- a/src/main/scala/org/scalacheck/util/Buildable.scala
+++ b/src/main/scala/org/scalacheck/util/Buildable.scala
@@ -22,33 +22,14 @@ trait Buildable[T,C] extends Serializable {
 
 object Buildable extends BuildableVersionSpecific {
   import java.util.ArrayList
-  implicit def buildableArrayList[T]: Buildable[T, ArrayList[T]] = new Buildable[T,ArrayList[T]] {
-    def builder = new ArrayListBuilder[T]
-  }
+  implicit def buildableArrayList[T]: Buildable[T, ArrayList[T]] =
+    new Buildable[T, ArrayList[T]] {
+      def builder = new ArrayListBuilder[T]
+    }
+
+  implicit def buildableSeq[T]: Buildable[T, Seq[T]] =
+    new Buildable[T, Seq[T]] {
+      def builder: mutable.Builder[T, Seq[T]] =
+        Seq.newBuilder[T]
+    }
 }
-
-/*
-object Buildable2 {
-
-  implicit def buildableMutableMap[T,U] = new Buildable2[T,U,mutable.Map] {
-    def builder = mutable.Map.newBuilder
-  }
-
-  implicit def buildableImmutableMap[T,U] = new Buildable2[T,U,immutable.Map] {
-    def builder = immutable.Map.newBuilder
-  }
-
-  implicit def buildableMap[T,U] = new Buildable2[T,U,Map] {
-    def builder = Map.newBuilder
-  }
-
-  implicit def buildableImmutableSortedMap[T: Ordering, U] = new Buildable2[T,U,immutable.SortedMap] {
-    def builder = immutable.SortedMap.newBuilder
-  }
-
-  implicit def buildableSortedMap[T: Ordering, U] = new Buildable2[T,U,SortedMap] {
-    def builder = SortedMap.newBuilder
-  }
-
-}
-*/


### PR DESCRIPTION
There are five changes which I've made to help ScalaCheck generate
values faster. They are:

 * Use custom buildableOfN implementation instead of sequence
 * Use Gen.stringOf and Gen.stringOfN instead of generic builders
 * Rewrite Gen[Char] instances to be faster
 * Remove as much indirection as possible
 * Stop using sieve/sieveCopy internally

There are also some changes that clean things up:

 * Add Gen.unicodeChar and Gen.unicodeStr
 * Add a Buildable[T, Seq[T]] instance
 * Add type annotations on some methods without them
 * A few indentation and formatting changes

The first 4 optimizations should not change any behavior users see
(except possibly balancing out some unbalanced character distributions
we had prevoiusly). The last change is a bit more controversial, and
will be discussed below.

Here are our benchmarks before the changes:

```
Benchmark                   (genSize)  (seedCount)  Mode  Cnt     Score      Error  Units
GenBench.asciiPrintableStr        100          100  avgt    3  1707.101 ± 2575.431  us/op
GenBench.const_                   100          100  avgt    3     3.431 ±    1.417  us/op
GenBench.double_                  100          100  avgt    3    13.103 ±   42.670  us/op
GenBench.dynamicFrequency         100          100  avgt    3  1804.406 ±  753.188  us/op
GenBench.eitherIntInt             100          100  avgt    3    42.499 ±   14.959  us/op
GenBench.identifier               100          100  avgt    3  3493.749 ± 1272.181  us/op
GenBench.int_                     100          100  avgt    3    13.364 ±    6.165  us/op
GenBench.listOfInt                100          100  avgt    3  1536.995 ±  370.880  us/op
GenBench.mapOfIntInt              100          100  avgt    3  3375.948 ±  588.872  us/op
GenBench.oneOf                    100          100  avgt    3    19.542 ±   14.573  us/op
GenBench.optionInt                100          100  avgt    3    52.750 ±    2.814  us/op
GenBench.sequence                 100          100  avgt    3   215.349 ±    0.736  us/op
GenBench.staticFrequency          100          100  avgt    3  1472.478 ±  655.671  us/op
GenBench.zipIntInt                100          100  avgt    3    26.897 ±    5.523  us/op
```

And after:

```
Benchmark                   (genSize)  (seedCount)  Mode  Cnt     Score      Error  Units
GenBench.asciiPrintableStr        100          100  avgt    3   204.613 ±  208.688  us/op
GenBench.const_                   100          100  avgt    3     2.856 ±    6.079  us/op
GenBench.double_                  100          100  avgt    3    11.058 ±   17.209  us/op
GenBench.dynamicFrequency         100          100  avgt    3   498.426 ±  306.193  us/op
GenBench.eitherIntInt             100          100  avgt    3    33.225 ±   10.462  us/op
GenBench.identifier               100          100  avgt    3    96.309 ±    4.903  us/op
GenBench.int_                     100          100  avgt    3     9.213 ±    2.990  us/op
GenBench.listOfInt                100          100  avgt    3   448.545 ±  228.448  us/op
GenBench.mapOfIntInt              100          100  avgt    3  1778.107 ± 1532.473  us/op
GenBench.oneOf                    100          100  avgt    3    18.858 ±   24.069  us/op
GenBench.optionInt                100          100  avgt    3    45.695 ±   18.507  us/op
GenBench.sequence                 100          100  avgt    3   198.399 ±  164.050  us/op
GenBench.staticFrequency          100          100  avgt    3   449.571 ±   97.772  us/op
GenBench.zipIntInt                100          100  avgt    3    24.025 ±   27.260  us/op
```

Some notable speed increases include:

 * asciiPrintableStr (8.5x faster)
 * dynamicFrequency (3.6x faster)
 * identifier (36.4x faster)
 * listOfInt (3.4x faster)
 * mapOfIntInt (1.9x faster)
 * staticFrequency (3.3x faster)

The speed improvements mostly affects collections, particularly
strings. Since these represent a significant portion of values
ScalaCheck users are likely to generate, this will probably help
shorten test runtime for our users. For example, running the Paiges
tests in this branch resulted in a roughly 2x speed up in time (as
measured by SBT).

The one optimization we might chose to forgoe is deprecating sieves.
Sieves were introduced to allow filtering predicates (introduced by
calling .suchThat or .filter on Gen[T] values) to be preserved in the
generated results. One strange consequence of that is that Gen.R holds
onto values which might be filtered out -- the acutal filtering is
done when .retrieve is called. Another is that many of the collection
combinators include .forall checks to try to verify that their
elements are legitimate.

The reason sieves were added was to support shrinking. The shrinking
code uses the sieve to filter the stream of shrunken values to try to
ensure that only "valid" values are produced. Since users tend to
avoid using filter (because of the issues around flaky test failures
due to too many discarded cases) and since most actual Gen instances
fail to shrink properly anyway, these sieves have likely not benefited
too many users. However, there's a risk that for some users removing
sieves will exacerbate shrinking issues they already have.

I'd like to consider removing sieves, since as it stands I'm not sure
they are consistently used, and using them doesn't solve the problems
we have with shrinking. However, I'll also benchmark this branch with
sieves put back in, and if the difference in performance is minor we
may want to leave sieves alone for now.