### PR TITLE
Update dotty to 0.20.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ matrix:
       script:
       - cd scalafix
       - sbt tests/test
-    - scala: 0.19.0-RC1
+    - scala: 0.20.0-RC1
       env: PLATFORM=jvm SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
   exclude:
     - jdk: openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -174,7 +174,7 @@ lazy val jvm = project.in(file("jvm"))
       !isDotty.value // ==> true
       // else ==> false
     },
-    crossScalaVersions += "0.19.0-RC1",
+    crossScalaVersions += "0.20.0-RC1",
     fork in Test := {
       // Serialization issue in 2.13 and later
       scalaMajorVersion.value == 13 || isDotty.value // ==> true

--- a/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
@@ -30,7 +30,7 @@ object ArbitrarySpecification extends Properties("Arbitrary") {
       Gen.delay(Arbitrary.arbitrary[Option[Recur]])
         .map(Recur(_))
     }
-    Prop.forAll { _: Recur =>
+    Prop.forAll { (_: Recur) =>
       Prop.passed
     }
   }
@@ -41,7 +41,7 @@ object ArbitrarySpecification extends Properties("Arbitrary") {
         .map(Recur(_))
     }
     Prop.throws(classOf[java.lang.StackOverflowError]) {
-      Prop.forAll { _: Recur =>
+      Prop.forAll { (_: Recur) =>
         Prop.passed
       }
     }

--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -199,7 +199,7 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
     s.drop(n & 0xffff).nonEmpty
   }
 
-  property("someOf") = forAll { l: List[Int] =>
+  property("someOf") = forAll { (l: List[Int]) =>
     forAll(someOf(l))(_.toList.forall(l.contains))
   }
 
@@ -224,8 +224,8 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
   property("distributed pick") = {
     val lst = (1 to 4).toIterable
     val n = 3
-    forAll(pick(n, lst)) { xs: collection.Seq[Int] =>
-      xs.map { x: Int =>
+    forAll(pick(n, lst)) { (xs: collection.Seq[Int]) =>
+      xs.map { (x: Int) =>
         Prop.collect(x) {
           xs.size == n
         }
@@ -338,22 +338,22 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
 
   // BigDecimal generation is tricky; just ensure that the generator gives
   // its constructor valid values.
-  property("BigDecimal") = forAll { _: BigDecimal => true }
+  property("BigDecimal") = forAll { (_: BigDecimal) => true }
 
   property("resultOf1") = forAll(resultOf((m: Int) => 0))(_ == 0)
 
   property("resultOf2") = {
     case class A(m: Int, s: String)
-    forAll(resultOf(A)) { a:A => true }
+    forAll(resultOf(A)) { (a:A) => true }
   }
 
   property("resultOf3") = {
     case class B(n: Int, s: String, b: Boolean)
     implicit val arbB: Arbitrary[B] = Arbitrary(resultOf(B))
-    forAll { b:B => true }
+    forAll { (b:B) => true }
   }
 
-  property("option") = forAll { n: Int =>
+  property("option") = forAll { (n: Int) =>
     forAll(option(n)) {
       case Some(m) if m == n => true
       case None => true
@@ -361,7 +361,7 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
     }
   }
 
-  property("some") = forAll { n: Int =>
+  property("some") = forAll { (n: Int) =>
     forAll(some(n)) {
       case Some(m) => m == n
       case _ => false
@@ -420,15 +420,15 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
     .suchThat(!_.isEmpty)
     .suchThat(!_.contains(','))
 
-  property("suchThat combined #98") = forAll(suchThatGen) { str: String =>
+  property("suchThat combined #98") = forAll(suchThatGen) { (str: String) =>
     !(str.isEmpty || str.contains(','))
   }
 
-  property("suchThat 1 #98") = forAll(suchThatGen) { str: String =>
+  property("suchThat 1 #98") = forAll(suchThatGen) { (str: String) =>
     !str.isEmpty
   }
 
-  property("suchThat 2 #98") = forAll(suchThatGen) { str: String =>
+  property("suchThat 2 #98") = forAll(suchThatGen) { (str: String) =>
     !str.contains(',')
   }
   ////

--- a/jvm/src/test/scala/org/scalacheck/PropertyFilterSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/PropertyFilterSpecification.scala
@@ -70,7 +70,7 @@ object PropertyFilterSpecification extends Properties("PropertyFilter") {
                   "PropertyFilterSample.negative numbers"
                 )
 
-                prop(pf, propNames, expected)
+              prop(pf, propNames, expected)
             } else if (pf.exists(_.contains("*alpha"))) {
               val expected = Seq("PropertyFilterSample.lowercase alpha characters")
 

--- a/jvm/src/test/scala/org/scalacheck/ShrinkSpecificationJVM.scala
+++ b/jvm/src/test/scala/org/scalacheck/ShrinkSpecificationJVM.scala
@@ -9,18 +9,18 @@ import ShrinkSpecification.shrinkClosure
   */
 object ShrinkSpecificationJVM extends Properties("Shrink JVM") {
 
-  property("list") = forAll { l: List[Int] =>
+  property("list") = forAll { (l: List[Int]) =>
     !shrink(l).contains(l)
   }
 
-  property("non-empty list") = forAll { l: List[Int] =>
+  property("non-empty list") = forAll { (l: List[Int]) =>
     (!l.isEmpty && l != List(0)) ==> {
       val ls = shrinkClosure(l)
       ls.toList.toString |: (ls.contains(Nil) && ls.contains(List(0)))
     }
   }
 
-  property("xmap vector from list") = forAll { v: Vector[Int] =>
+  property("xmap vector from list") = forAll { (v: Vector[Int]) =>
     (!v.isEmpty && v != Vector(0)) ==> {
       val vs = shrinkClosure(v)
       Vector(vs: _*).toString |: (vs.contains(Vector.empty) && vs.contains(Vector(0)))

--- a/jvm/src/test/scala/org/scalacheck/TestSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/TestSpecification.scala
@@ -28,7 +28,7 @@ object TestSpecification extends Properties("Test") {
 
   val shrunk = forAll( (t: (Int,Int,Int)) => false )
 
-  val propException = forAll { n:Int => throw new java.lang.Exception }
+  val propException = forAll { (n:Int) => throw new java.lang.Exception }
 
   val undefinedInt = for{
     n <- arbitrary[Int]
@@ -36,7 +36,7 @@ object TestSpecification extends Properties("Test") {
 
   val genException = forAll(undefinedInt)((n: Int) => true)
 
-  property("workers") = forAll { prms: Test.Parameters =>
+  property("workers") = forAll { (prms: Test.Parameters) =>
     var res = true
 
     val cb = new Test.TestCallback {
@@ -75,48 +75,48 @@ object TestSpecification extends Properties("Test") {
     }
   }
 
-  property("size") = forAll { prms: Test.Parameters =>
+  property("size") = forAll { (prms: Test.Parameters) =>
     val p = sizedProp { sz => sz >= prms.minSize && sz <= prms.maxSize }
     Test.check(prms, p).status == Passed
   }
 
-  property("propFailing") = forAll { prms: Test.Parameters =>
+  property("propFailing") = forAll { (prms: Test.Parameters) =>
     Test.check(prms, failing).status match {
       case _:Failed => true
       case _ => false
     }
   }
 
-  property("propPassing") = forAll { prms: Test.Parameters =>
+  property("propPassing") = forAll { (prms: Test.Parameters) =>
     Test.check(prms, passing).status == Passed
   }
 
-  property("propProved") = forAll { prms: Test.Parameters =>
+  property("propProved") = forAll { (prms: Test.Parameters) =>
     Test.check(prms, proved).status match {
       case _:Test.Proved => true
       case _ => false
     }
   }
 
-  property("propExhausted") = forAll { prms: Test.Parameters =>
+  property("propExhausted") = forAll { (prms: Test.Parameters) =>
     Test.check(prms, exhausted).status == Exhausted
   }
 
-  property("propPropException") = forAll { prms: Test.Parameters =>
+  property("propPropException") = forAll { (prms: Test.Parameters) =>
     Test.check(prms, propException).status match {
       case _:PropException => true
       case _ => false
     }
   }
 
-  property("propGenException") = forAll { prms: Test.Parameters =>
+  property("propGenException") = forAll { (prms: Test.Parameters) =>
     Test.check(prms, genException).status match {
       case x:PropException => true :| x.toString
       case x => false :| x.toString
     }
   }
 
-  property("propShrunk") = forAll { prms: Test.Parameters =>
+  property("propShrunk") = forAll { (prms: Test.Parameters) =>
     Test.check(prms, shrunk).status match {
       case Failed(Arg(_,(x:Int,y:Int,z:Int),_,_,_,_)::Nil,_) =>
         x == 0 && y == 0 && z == 0

--- a/jvm/src/test/scala/org/scalacheck/examples/IntMapSpec.scala
+++ b/jvm/src/test/scala/org/scalacheck/examples/IntMapSpec.scala
@@ -22,11 +22,11 @@ object IntMapSpec extends org.scalacheck.Properties("IntMap") {
     (hm, im)
   }
 
-  property("size") = forAll { l: List[Int] =>
+  property("size") = forAll { (l: List[Int]) =>
     val (refMap, intMap) = createMaps(l)
     intMap.size ?= refMap.size
   }
-  property("isEmpty") = forAll { l: List[Int] =>
+  property("isEmpty") = forAll { (l: List[Int]) =>
     val (refMap, intMap) = createMaps(l)
     intMap.isEmpty ?= refMap.isEmpty
   }

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -280,7 +280,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   /** Generates an arbitrary property */
   implicit lazy val arbProp: Arbitrary[Prop] = {
     import Prop._
-    val undecidedOrPassed = forAll { b: Boolean =>
+    val undecidedOrPassed = forAll { (b: Boolean) =>
       b ==> true
     }
     Arbitrary(frequency(

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -108,7 +108,7 @@ sealed abstract class Gen[+T] extends Serializable { self =>
     def doApply(p: P, seed: Seed) =
       p.useInitialSeed(seed) { (p0, s0) =>
         val res = Gen.this.doApply(p0, s0)
-        res.copy(s = { x:T => res.sieve(x) && f(x) })
+        res.copy(s = { (x: T) => res.sieve(x) && f(x) })
       }
     override def sieveCopy(x: Any) =
       try Gen.this.sieveCopy(x) && f(x.asInstanceOf[T])

--- a/src/main/scala/org/scalacheck/Shrink.scala
+++ b/src/main/scala/org/scalacheck/Shrink.scala
@@ -51,7 +51,7 @@ object Shrink extends ShrinkLowPriority {
   /** Shrink instance of container */
   implicit def shrinkContainer[C[_],T](implicit v: C[T] => Traversable[T], s: Shrink[T],
     b: Buildable[T,C[T]]
-  ): Shrink[C[T]] = Shrink { xs: C[T] =>
+  ): Shrink[C[T]] = Shrink { (xs: C[T]) =>
     val ys = v(xs)
     val zs = ys.toStream
     removeChunks(ys.size,zs).append(shrinkOne(zs)).map(b.fromIterable)
@@ -60,7 +60,7 @@ object Shrink extends ShrinkLowPriority {
   /** Shrink instance of container2 */
   implicit def shrinkContainer2[C[_,_],T,U](implicit v: C[T,U] => Traversable[(T,U)], s: Shrink[(T,U)],
     b: Buildable[(T,U),C[T,U]]
-  ): Shrink[C[T,U]] = Shrink { xs: C[T,U] =>
+  ): Shrink[C[T,U]] = Shrink { (xs: C[T,U]) =>
     val ys = v(xs)
     val zs = ys.toStream
     removeChunks(ys.size,zs).append(shrinkOne(zs)).map(b.fromIterable)
@@ -227,7 +227,7 @@ object Shrink extends ShrinkLowPriority {
   /** Transform a Shrink[T] to a Shrink[U] where T and U are two isomorphic types
     *  whose relationship is described by the provided transformation functions.
     *  (exponential functor map) */
-  def xmap[T, U](from: T => U, to: U => T)(implicit st: Shrink[T]): Shrink[U] = Shrink[U] { u: U =>
+  def xmap[T, U](from: T => U, to: U => T)(implicit st: Shrink[T]): Shrink[U] = Shrink[U] { (u: U) =>
     st.shrink(to(u)).map(from)
   }
 }

--- a/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -22,7 +22,7 @@ object PropSpecification extends Properties("Prop") {
     throw new java.lang.Exception("exception")
   }
 
-  property("Prop.==> undecided") = forAll { p1: Prop =>
+  property("Prop.==> undecided") = forAll { (p1: Prop) =>
     val g = oneOf(falsified,undecided)
     forAll(g) { p2 =>
       val p3 = (p2 ==> p1)
@@ -39,7 +39,7 @@ object PropSpecification extends Properties("Prop") {
     }
   }
 
-  property("Prop.==> short circuit") = forAll { n: Int =>
+  property("Prop.==> short circuit") = forAll { (n: Int) =>
     def positiveDomain(n: Int): Boolean = n match {
       case n if n > 0 => true
       case n if (n & 1) == 0 => throw new java.lang.Exception("exception")
@@ -58,7 +58,7 @@ object PropSpecification extends Properties("Prop") {
     val g = oneOf(proved,passed,falsified,undecided,exception)
     forAll(g,g) { case (p1,p2) => (p1 && p2) == (p2 && p1) }
   }
-  property("Prop.&& Exception") = forAll { p: Prop =>
+  property("Prop.&& Exception") = forAll { (p: Prop) =>
     (p && propException()) == exception
   }
   property("Prop.&& Exception 2") = {
@@ -68,7 +68,7 @@ object PropSpecification extends Properties("Prop") {
     val g = oneOf(proved,passed,falsified,undecided,exception)
     forAll(g)(p => (p && proved) == p)
   }
-  property("Prop.&& False") = forAll { p: Prop =>
+  property("Prop.&& False") = forAll { (p: Prop) =>
     val q = p && falsified
     q == falsified || (q == exception && p == exception)
   }
@@ -85,7 +85,7 @@ object PropSpecification extends Properties("Prop") {
     val g = oneOf(proved,passed,falsified,undecided,exception)
     forAll(g,g) { case (p1,p2) => (p1 || p2) == (p2 || p1) }
   }
-  property("Prop.|| Exception") = forAll { p: Prop =>
+  property("Prop.|| Exception") = forAll { (p: Prop) =>
     (p || propException()) == exception
   }
   property("Prop.|| Identity") = {
@@ -105,7 +105,7 @@ object PropSpecification extends Properties("Prop") {
     val g = oneOf(proved,passed,falsified,undecided,exception)
     forAll(g,g) { case (p1,p2) => (p1 ++ p2) == (p2 ++ p1) }
   }
-  property("Prop.++ Exception") = forAll { p: Prop =>
+  property("Prop.++ Exception") = forAll { (p: Prop) =>
     (p ++ propException()) == exception
   }
   property("Prop.++ Identity 1") = {
@@ -121,11 +121,11 @@ object PropSpecification extends Properties("Prop") {
     forAll(g)(p => (p ++ falsified) == falsified)
   }
 
-  property("undecided") = forAll { prms: Parameters =>
+  property("undecided") = forAll { (prms: Parameters) =>
     undecided(prms).status == Undecided
   }
 
-  property("falsified") = forAll { prms: Parameters =>
+  property("falsified") = forAll { (prms: Parameters) =>
     falsified(prms).status == False
   }
 

--- a/src/test/scala/org/scalacheck/ShrinkSpecification.scala
+++ b/src/test/scala/org/scalacheck/ShrinkSpecification.scala
@@ -22,82 +22,82 @@ object ShrinkSpecification extends Properties("Shrink") {
     else xs.append(xs.take(1).map(shrinkClosure[T]).flatten)
   }
 
-  property("byte") = forAll { n: Byte =>
+  property("byte") = forAll { (n: Byte) =>
     !shrink(n).contains(n)
   }
 
-  property("short") = forAll { n: Short =>
+  property("short") = forAll { (n: Short) =>
     !shrink(n).contains(n)
   }
 
-  property("int") = forAll { n: Int =>
+  property("int") = forAll { (n: Int) =>
     !shrink(n).contains(n)
   }
 
-  property("long") = forAll { n: Long =>
+  property("long") = forAll { (n: Long) =>
     !shrink(n).contains(n)
   }
 
-  property("float") = forAll { n: Float =>
+  property("float") = forAll { (n: Float) =>
     !shrink(n).contains(n)
   }
 
-  property("double") = forAll { n: Double =>
+  property("double") = forAll { (n: Double) =>
     !shrink(n).contains(n)
   }
 
-  property("duration") = forAll { n: Duration =>
+  property("duration") = forAll { (n: Duration) =>
     !shrink(n).contains(n)
   }
 
-  property("finite duration") = forAll { n: FiniteDuration =>
+  property("finite duration") = forAll { (n: FiniteDuration) =>
     !shrink(n).contains(n)
   }
 
-  property("non-zero byte") = forAll { n: Byte =>
+  property("non-zero byte") = forAll { (n: Byte) =>
     (n != 0) ==> shrinkClosure(n).contains(0)
   }
 
-  property("non-zero short") = forAll { n: Short =>
+  property("non-zero short") = forAll { (n: Short) =>
     (n != 0) ==> shrinkClosure(n).contains(0)
   }
 
-  property("non-zero int") = forAll { n: Int =>
+  property("non-zero int") = forAll { (n: Int) =>
     (n != 0) ==> shrinkClosure(n).contains(0)
   }
 
-  property("non-zero long") = forAll { n: Long =>
+  property("non-zero long") = forAll { (n: Long) =>
     (n != 0) ==> shrinkClosure(n).contains(0)
   }
 
-  property("non-zero float") = forAll { n: Float =>
+  property("non-zero float") = forAll { (n: Float) =>
     (math.abs(n) > 1E-5f) ==> shrinkClosure(n).contains(0)
   }
 
-  property("non-zero double") = forAll { n: Double =>
+  property("non-zero double") = forAll { (n: Double) =>
     (math.abs(n) > 1E-5d) ==> shrinkClosure(n).contains(0)
   }
 
-  property("non-zero finite duration") = forAll { n: FiniteDuration =>
+  property("non-zero finite duration") = forAll { (n: FiniteDuration) =>
     (n != Duration.Zero) ==> shrinkClosure(n).contains(Duration.Zero)
   }
 
-  property("non-zero duration") = forAll { n: Duration =>
+  property("non-zero duration") = forAll { (n: Duration) =>
     (n.isFinite && n != Duration.Zero) ==> shrinkClosure(n).contains(Duration.Zero)
   }
 
   implicit def vectorShrink[A: Shrink]: Shrink[Vector[A]] = Shrink.xmap[List[A],Vector[A]](Vector(_: _*), _.toList)
 
-  property("either shrinks") = forAll { e: Either[Int, Long] =>
+  property("either shrinks") = forAll { (e: Either[Int, Long]) =>
     !shrink(e).contains(e)
   }
 
-  property("either left") = forAll { i: Int =>
+  property("either left") = forAll { (i: Int) =>
     val e: Either[Int, Long] = Left(i)
     shrink(e).forall(_.isLeft)
   }
 
-  property("either right") = forAll { i: Int =>
+  property("either right") = forAll { (i: Int) =>
     val e: Either[Long, Int] = Right(i)
     shrink(e).forall(_.isRight)
   }

--- a/src/test/scala/org/scalacheck/examples/Examples.scala
+++ b/src/test/scala/org/scalacheck/examples/Examples.scala
@@ -8,7 +8,7 @@ object Examples extends Properties("Examples") {
     (n :: l).tail == l
   }
 
-  property("list head") = Prop.forAll { l: List[Int] =>
+  property("list head") = Prop.forAll { (l: List[Int]) =>
     if (l.isEmpty) {
       Prop.throws(classOf[java.util.NoSuchElementException]) { l.head }
     } else {
@@ -37,7 +37,7 @@ object Examples extends Properties("Examples") {
 
   implicit val arbPerson: Arbitrary[Person] = Arbitrary(genPerson)
 
-  property("ex1") = Prop.forAll { p: Person =>
+  property("ex1") = Prop.forAll { (p: Person) =>
     p.isTeenager == (p.age >= 13 && p.age <= 19)
   }
 

--- a/src/test/scala/org/scalacheck/examples/MathSpec.scala
+++ b/src/test/scala/org/scalacheck/examples/MathSpec.scala
@@ -3,7 +3,7 @@ package org.scalacheck.examples
 import org.scalacheck.Prop.{forAll, propBoolean}
 
 object MathSpec extends org.scalacheck.Properties("Math") {
-  property("sqrt") = forAll { n: Int =>
+  property("sqrt") = forAll { (n: Int) =>
     (n >= 0) ==> {
       val m = math.sqrt(n.toDouble)
       math.round(m*m) == n

--- a/src/test/scala/org/scalacheck/util/Pretty.scala
+++ b/src/test/scala/org/scalacheck/util/Pretty.scala
@@ -19,7 +19,7 @@ object PrettySpecification extends Properties("Pretty") {
   property("pretty(null: Any)") = Pretty.pretty(null: Any) == "null"
 
   property("break") = {
-    Prop.forAll { s: String =>
+    Prop.forAll { (s: String) =>
       Prop.forAllNoShrink(Gen.oneOf("", "  ")) { lead =>
         val length = 75
         val result = Pretty.break(s, lead, length)


### PR DESCRIPTION
https://dotty.epfl.ch/blog/2019/11/04/20th-dotty-milestone-release.html

- Fix migration warnings:

```
-- Migration Warning: scalacheck/src/main/scala/org/scalacheck/Arbitrary.scala:283:37 
283 |    val undecidedOrPassed = forAll { b: Boolean =>
    |                                     ^^^^^^^^^^
    |parentheses are required around the parameter of a lambda
```

- Fix whitespace warnings:

```
-- Warning: scalacheck/jvm/src/test/scala/org/scalacheck/PropertyFilterSpecification.scala:73:16 
73 |                prop(pf, propNames, expected)
   |                ^
   |      Line is indented too far to the right, or a `{' is missing
```

- ~~Fix warnings around `implicitConversions`~~

```
-- Feature Warning: scalacheck/src/main/scala/org/scalacheck/Shrink.scala:250:39 
250 |    else if (skipNegation) q #:: halves(q)
    |                                 ^^^^^^^^^
    |Use of implicit conversion method toDeferrer in object Stream should be enabled
    |by making the implicit value scala.language.implicitConversions visible.
    |This can be achieved by adding the import clause 'import scala.language.implicitConversions'
    |or by setting the compiler option -language:implicitConversions.
```