### PR TITLE
Add Cogen.domainOf

### DIFF
--- a/src/main/scala/org/scalacheck/Cogen.scala
+++ b/src/main/scala/org/scalacheck/Cogen.scala
@@ -167,6 +167,8 @@ object Cogen extends CogenArities with CogenLowPriority with CogenVersionSpecifi
     while (i < as.length) { s = A.perturb(s, as(i)); i += 1 }
     s.next
   }
+
+  def domainOf[A, B](f: A => B)(implicit B: Cogen[B]): Cogen[A] = B.contramap(f)
 }
 
 trait CogenLowPriority {


### PR DESCRIPTION
Closes #589

I'm not sure about the name. `resultOf` doesn't fit (we're creating `Cogen` for the domain of the function). I'm using `domainOf` for now, but I'm open to suggestions.

I didn't add any tests since this is just sugar over `contramap`.