### PR TITLE
Add smoke test of benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,9 @@ matrix:
       script:
       - cd examples
       - for d in */ ; do cd "$d" && sbt test:compile && cd ../ ; done
+    - env: BENCH
+      script:
+      - sbt "+bench/jmh:run -p genSize=0 -p seedCount=0 -bs 1 -wi 0 -i 1 -f 0 -t 1 -r 0 org.scalacheck.bench.GenBench"
     - env: SCALAFIX
       script:
       - cd scalafix


### PR DESCRIPTION
Use a long list of command-line args to JMH so that it just runs once and quickly.