### PR TITLE
Upgrade Scala.js to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ env:
   matrix:
     - PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=false
     - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false
-    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-RC2
+    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0
     - PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=true
     - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
-    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0-RC2
+    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0
 sudo: false
 
 before_cache:
@@ -71,24 +71,24 @@ matrix:
     - jdk: openjdk8
       env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false
     - jdk: openjdk8
-      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-RC2
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0
     - jdk: openjdk11
       env: PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=true
     - jdk: openjdk11
       env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
     - jdk: openjdk11
-      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0-RC2
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0
     - scala: 2.11.12
-      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-RC2
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0
     - scala: 2.11.12
-      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0-RC2
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0
     - jdk: openjdk11
       env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false
     - jdk: openjdk11
       env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
     - jdk: openjdk11
-      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0-RC2
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=false SCALAJS_VERSION=1.0.0
     - jdk: openjdk11
-      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0-RC2
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true  SCALAJS_VERSION=1.0.0
     - jdk: openjdk11
       scala: 2.11.12

--- a/examples/scalajs/README.md
+++ b/examples/scalajs/README.md
@@ -24,7 +24,7 @@ The following is what you need to add to your `build.sbt` file to make the
 ScalaCheck test runner work:
 
 ```
-libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.14.2" % "test"
+libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.14.3" % "test"
 ```
 
 ## Limitations

--- a/examples/scalajs/build.sbt
+++ b/examples/scalajs/build.sbt
@@ -6,4 +6,4 @@ version := "0.1-SNAPSHOT"
 
 scalaVersion := "2.12.10"
 
-libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.14.2" % "test"
+libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.14.3" % "test"

--- a/examples/scalajs/project/plugins.sbt
+++ b/examples/scalajs/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0")

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -15,7 +15,7 @@ def printAndDie(msg: String): Nothing = {
 // Update SCALAJS_VERSION in release.sh, as well
 val scalaJSVersion = env("SCALAJS_VERSION") match {
   case Some("0.6.32") | None => "0.6.32"
-  case Some("1.0.0-RC2") => "1.0.0-RC2"
+  case Some("1.0.0") => "1.0.0"
   case Some(v) => printAndDie(s"unsupported scala.js version: $v")
 }
 

--- a/release.sh
+++ b/release.sh
@@ -55,7 +55,7 @@ runsbt "+ jvm/$CMD"
 # step 4b: js releases (clean versions)
 SCALAJS_VERSION="0.6.32" runsbt "+ js/$CMD"
 runsbt "+ js/clean"
-SCALAJS_VERSION="1.0.0-RC2" runsbt "+ js/$CMD"
+SCALAJS_VERSION="1.0.0" runsbt "+ js/$CMD"
 
 # step 4c: native releases (clean versions)
 SCALANATIVE_VERSION="0.3.9" runsbt "+ native/$CMD"


### PR DESCRIPTION
Finally Scala.js 1.0.0 has been released https://github.com/scala-js/scala-js/releases/tag/v1.0.0