### PR TITLE
Adds helper to create Shrink using LazyList

### DIFF
--- a/src/main/scala-2.13+/org/scalacheck/ScalaVersionSpecific.scala
+++ b/src/main/scala-2.13+/org/scalacheck/ScalaVersionSpecific.scala
@@ -38,3 +38,8 @@ private[scalacheck] trait CogenVersionSpecific {
   implicit def cogenLazyList[A: Cogen]: Cogen[LazyList[A]] =
     Cogen.it(_.iterator)
 }
+
+private[scalacheck] trait ShrinkVersionSpecific {
+  /** Forward to Shrink instance factory */
+  def withLazyList[T](s: T => LazyList[T]): Shrink[T] = Shrink(s.andThen(_.toStream))
+}

--- a/src/main/scala-2.13-/org/scalacheck/ScalaVersionSpecific.scala
+++ b/src/main/scala-2.13-/org/scalacheck/ScalaVersionSpecific.scala
@@ -37,3 +37,5 @@ private[scalacheck] trait CogenVersionSpecific
 private[scalacheck] trait GenSpecificationVersionSpecific {
   def infiniteLazyList[T](g: => Gen[T]): Gen[Stream[T]] = Gen.infiniteStream(g)
 }
+
+private[scalacheck] trait ShrinkVersionSpecific

--- a/src/main/scala/org/scalacheck/Shrink.scala
+++ b/src/main/scala/org/scalacheck/Shrink.scala
@@ -24,7 +24,7 @@ trait ShrinkLowPriority {
   implicit def shrinkAny[T]: Shrink[T] = Shrink(_ => Stream.empty)
 }
 
-object Shrink extends ShrinkLowPriority {
+object Shrink extends ShrinkLowPriority with ShrinkVersionSpecific {
 
   import Stream.{cons, empty}
   import scala.collection._


### PR DESCRIPTION
This allows to use Shrink from scala 2.13 without getting deprecation
warnings on scala.collection.immutable.Stream

fixes #626 