### PR TITLE
Fail at generating Command sequences less often

### DIFF
--- a/src/main/scala/org/scalacheck/commands/Commands.scala
+++ b/src/main/scala/org/scalacheck/commands/Commands.scala
@@ -365,7 +365,7 @@ trait Commands {
       l.foldLeft(const((s,Nil:Commands))) { case (g,()) =>
         for {
           (s0,cs) <- g
-          c <- genCommand(s0) suchThat (_.preCondition(s0))
+          c <- genCommand(s0) retryUntil (_.preCondition(s0), 100)
         } yield (c.nextState(s0), cs :+ c)
       }
     }


### PR DESCRIPTION
See https://gist.github.com/jonaskoelker/ac60ded3a310b8f0fb548a1eda9f8859 and https://gist.github.com/jonaskoelker/b4a1d00a3da97c6d56e7b3d8fee02716.

Without this change, the `BoundedQueueSpec` would fail at command generation unless you added `.retryUntil(cmd => cmd.preCondition(state))` to the end of `genCommand`. With this change, command generation no longer fails.

I found one semi-related discussion at https://github.com/typelevel/scalacheck/issues/568. However that issue gets resolved, I don't think that has any bearing on whether retrying in a Commands context is a good idea or not: while it's reasonable to expect `listOfN` to satisfy some sensible properties (e.g. `listOfN(1, g)` fails with the same probability as `g`, and I suppose `listOfN(k, g)` succeeds with probability `p^k` where `p` is the success probability of `g`), I would prefer the thing-similar-to-listOfN done in `Commands` to be more concerned about convenience in the form of a high success rate and dealing with the sequential data dependency due to state threading through a sequence of commands.

I can think of one argument against doing this: the user can always add `.retryUntil(cmd => cmd.preCondition(state))` themselves, but why not scrap that boilerplate for them? It's not obvious to me what the existing code does better.

I picked the number `100` somewhat arbitrarily: I guess (without having measured) that it's large enough to paper over most practically occurring generation failures and small enough to not be a performance nuisance if some generator always fails.