### PR TITLE
Print shrunk values first, then the _ORIGINAL values

### DIFF
--- a/src/main/scala/org/scalacheck/util/Pretty.scala
+++ b/src/main/scala/org/scalacheck/util/Pretty.scala
@@ -130,13 +130,15 @@ object Pretty {
 
   def prettyArgs(args: Seq[Arg[Any]]): Pretty = Pretty { prms =>
     if(args.isEmpty) "" else {
-      for((a,i) <- args.zipWithIndex) yield {
+      val labeledValues = for((a,i) <- args.zipWithIndex) yield {
         val l = "> "+(if(a.label == "") "ARG_"+i else a.label)
         val s =
-          if(a.shrinks == 0) ""
-          else "\n"+l+"_ORIGINAL: "+a.prettyOrigArg(prms)
-        l+": "+a.prettyArg(prms)+""+s
+          if(a.shrinks == 0) None
+          else Some(l+"_ORIGINAL: "+a.prettyOrigArg(prms))
+        (l+": "+a.prettyArg(prms), s)
       }
+      labeledValues.map(_._1) ++
+      labeledValues.map(_._2).collect { case Some(s) => s }
     }.mkString("\n")
   }
 


### PR DESCRIPTION
This makes `forAll { (x: Int, y: Int) => false }` fail as follows:

[info] > ARG_0: 0
[info] > ARG_1: 0
[info] > ARG_0_ORIGINAL: -1737265162
[info] > ARG_1_ORIGINAL: -1

instead of

[info] > ARG_0: 0
[info] > ARG_0_ORIGINAL: -1737265162
[info] > ARG_1: 0
[info] > ARG_1_ORIGINAL: -1

I prefer the former error message: when a property fails, I typically
want to see a set of inputs that made it fail.  The new layout shows
me first the shrunk set of inputs (with nothing else interleaved),
then the original set of inputs (with nothing else interleaved).