### PR TITLE
Fix a bug with initial seed support.

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/TestSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/TestSpecification.scala
@@ -167,4 +167,27 @@ object TestSpecification extends Properties("Test") {
       Prop.Result(status = if (ok) Prop.Proof else Prop.False)
     }
   }
+
+  property("initialSeed is used and then updated") = {
+    val seed = rng.Seed.fromBase64("aaaaa_mr05Z_DCbd2PyUolC0h93iH1MQwIdnH2UuI4L=").get
+    val gen = Gen.choose(Int.MinValue, Int.MaxValue)
+    val expected = gen(Gen.Parameters.default, seed).get
+
+    val prms = Test.Parameters.default
+      .withInitialSeed(Some(seed))
+      .withMinSuccessfulTests(10)
+
+    var xs: List[Int] = Nil
+    val prop = Prop.forAll(gen) { x =>
+      xs = x :: xs
+      true
+    }
+
+    val res = Test.check(prms, prop)
+    val n = xs.size
+    val unique = xs.toSet
+    val p0 = Prop(unique(expected)) :| s"did not see $expected in $unique"
+    val p1 = Prop(unique.size > 1) :| s"saw $n duplicate values: $unique"
+    p0 && p1
+  }
 }

--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -416,7 +416,7 @@ object Test {
       def isExhausted = d > params.minSuccessfulTests * params.maxDiscardRatio
 
       var seed = {
-        val seed0 = params.initialSeed.getOrElse(rng.Seed.random)
+        val seed0 = params.initialSeed.getOrElse(rng.Seed.random())
         if (workerIdx == 0) seed0 else seed0.reseed(workerIdx.toLong)
         //seed0.reseed(workerIdx.toLong)
       }

--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -418,7 +418,6 @@ object Test {
       var seed = {
         val seed0 = params.initialSeed.getOrElse(rng.Seed.random())
         if (workerIdx == 0) seed0 else seed0.reseed(workerIdx.toLong)
-        //seed0.reseed(workerIdx.toLong)
       }
 
       while(!stop && res == null && n < iterations) {


### PR DESCRIPTION
Prevously, the initial seed was used for every single property
evaluation, meaning that even if a property is evaluated 100 times the
same values will be used each time. This is not what users expect, and
makes the library harder to use.

(In particular, the MUnit library hit this bug using Test.check.)

After this commit, the initial seed will be used first, but then a
deterministic set of seeds will be used later. This sequence will be
the same for every run as long as the same number of workers are used.
If the number of workers is changed, the initial seed will be the
same, but the exact sequence of seeds used may differ somewhat.