### PR TITLE
Revert "Add Cogen.domainOf"

### DIFF
--- a/src/main/scala/org/scalacheck/Cogen.scala
+++ b/src/main/scala/org/scalacheck/Cogen.scala
@@ -167,8 +167,6 @@ object Cogen extends CogenArities with CogenLowPriority with CogenVersionSpecifi
     while (i < as.length) { s = A.perturb(s, as(i)); i += 1 }
     s.next
   }
-
-  def domainOf[A, B](f: A => B)(implicit B: Cogen[B]): Cogen[A] = B.contramap(f)
 }
 
 trait CogenLowPriority {


### PR DESCRIPTION
Reverts typelevel/scalacheck#590

This PR was apparently targeting the 1.14.x branch, but I think we should merge it into master instead.

@ashawley What do you think? Did you want this targeting 1.14.x?