### PR TITLE
Restore binary compatibility with 1.14.0

### DIFF
--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -19,7 +19,6 @@ object MimaSettings {
   )
 
   private def removedPrivateMethods = Seq(
-    "org.scalacheck.Prop.BooleanOperators"
   )
 
   private def removedPrivateClasses = Seq(

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -357,7 +357,7 @@ object Prop {
    * values available in the current scope. See [[Prop.ExtendedBoolean]] for
    * documentation on the operators. */
   @deprecated("Please import Prop.propBoolean instead", since="1.14.1")
-  implicit private[this] def BooleanOperators(b: => Boolean): ExtendedBoolean = new ExtendedBoolean(b)
+  def BooleanOperators(b: => Boolean): ExtendedBoolean = new ExtendedBoolean(b)
 
   /** Implicit conversion of Boolean values to Prop values. */
   implicit def propBoolean(b: Boolean): Prop = Prop(b)


### PR DESCRIPTION
dbaeb80e5f1e2aad36a647f4fe55fcfde9d1153e broke binary compatibility by
making `BooleanOperators` private, this does not match the plan discussed
in #540:

> The 1.15.x series will preserve binary-compatibility with 1.14.0 but
  is expected to break source-compatibility (e.g. removing the implicit
  keyword from some definitions)

This commit implements that: BooleanOperators is public again but is
also made non-implicit.