### PR TITLE
Make Gen[Tuple] serializable and add regression test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,13 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
 
   unmanagedSourceDirectories in Test += (baseDirectory in LocalRootProject).value / "src" / "test" / "scala",
 
+  unmanagedSourceDirectories in Test += {
+    val s = if (scalaMajorVersion.value >= 13 || isDotty.value) "+" else "-"
+    (baseDirectory in LocalRootProject).value / "src" / "test" / s"scala-2.13$s"
+  },
+
+  libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % "test",
+
   resolvers += "sonatype" at "https://oss.sonatype.org/content/repositories/releases",
 
   // 2.11 - 2.13

--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -634,43 +634,4 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
 
   property("Gen.choose(1, 10000) is deterministic") =
     testDeterministicGen(Gen.choose(1, 10000))
-
-  def testSerializable(obj: Any): Prop = {
-    val t = Try({
-      val baos = new ByteArrayOutputStream()
-      val oos = new ObjectOutputStream(baos)
-      oos.writeObject(obj)
-      oos.close()
-
-      // Reading it back in shouldn't throw, but we don't expect equality.
-      val bais = new ByteArrayInputStream(baos.toByteArray())
-      new ObjectInputStream(bais).readObject()
-      ()
-    })
-    t match {
-      case Success(_) => Prop(true)
-      case _          => Prop(false) :| s"Fail to serialize $obj"
-    }
-  }
-
-  def testSerializableGenAndValues[A](gen: Gen[A]): Prop =
-    testSerializable(gen) && forAll(gen)(testSerializable)
-
-  property("arbitrary[(String, Int)] and its produced values are serializable") =
-    testSerializableGenAndValues(arbitrary[(String, Int)])
-
-  property("cogen[(String, Int]) is serializable") =
-    testSerializable(Cogen[(String, Int)])
-
-  property("arbitrary[(String, Int, Int)] and its produced values are serializable") =
-    testSerializableGenAndValues(arbitrary[(String, Int, Int)])
-
-  property("arbitrary[List[Int] => List[(String, Int)]] and its produced values are serializable") =
-    testSerializableGenAndValues(arbitrary[List[Int] => List[(String, Int)]])
-
-  property("arbitrary[List[(String, Int)] => List[Int]] and its produced values are serializable") =
-    testSerializableGenAndValues(arbitrary[List[(String, Int)] => List[Int]])
-
-  property("arbitrary[List[(Int, (String, Int))] => List[(String, Int)]] and its produced values are serializable") =
-    testSerializableGenAndValues(arbitrary[List[(Int, (String, Int))] => List[(String, Int)]])
 }

--- a/project/codegen.scala
+++ b/project/codegen.scala
@@ -25,8 +25,7 @@ object codegen {
   def flatMappedGenerators(i: Int, s: Seq[(String,String)]): String =
     s.init.foldRight(s"${s.last._2}.map { ${s.last._1} => (${vals(i)}) }") {
       case ((t, g), acc) =>
-        val T = t.toUpperCase
-        s"${g}.flatMap(new Function1[${T}, Gen[(${types(i)})]] { def apply(${t}: ${T}): Gen[(${types(i)})] = $acc })"
+        s"${g}.flatMap(${t} => $acc)"
     }
   
   def vals(i: Int) = csv(idents("t",i))

--- a/src/test/scala-2.13+/org/scalacheck/SerializationSpecification.scala
+++ b/src/test/scala-2.13+/org/scalacheck/SerializationSpecification.scala
@@ -1,0 +1,73 @@
+package org.scalacheck
+
+import rng.Seed
+import scala.reflect.runtime.universe._
+import Gen._
+import Prop.{forAll, someFailing, noneFailing, sizedProp, secure, propBoolean}
+import Arbitrary._
+import Shrink._
+import org.scalacheck.util.Buildable
+import java.io.{
+  ByteArrayInputStream,
+  ByteArrayOutputStream,
+  ObjectInputStream,
+  ObjectOutputStream
+}
+import java.util.Date
+import scala.util.{Try, Success, Failure}
+import scala.concurrent.duration.Duration
+
+object SerializationSpecification extends Properties("Serialization") {
+  def testSerializable(obj: Any): Prop = {
+    val t = Try({
+      val baos = new ByteArrayOutputStream()
+      val oos = new ObjectOutputStream(baos)
+      oos.writeObject(obj)
+      oos.close()
+
+      // Reading it back in shouldn't throw, but we don't expect equality.
+      val bais = new ByteArrayInputStream(baos.toByteArray())
+      new ObjectInputStream(bais).readObject()
+      ()
+    })
+    t match {
+      case Success(_) => Prop(true)
+      case _          => Prop(false) :| s"Fail to serialize $obj"
+    }
+  }
+
+  def testSerializableGenAndValues[A](gen: Gen[A]): Prop =
+    testSerializable(gen) && forAll(gen)(testSerializable)
+
+  def testArbitraryAndCogen[A](implicit arb: Arbitrary[A], cogen: Cogen[A]): Prop =
+    testSerializable(cogen) && testSerializableGenAndValues(arb.arbitrary)
+
+  def registerTest[A](implicit tag: TypeTag[A], arb: Arbitrary[A], cogen: Cogen[A]): Unit = {
+    val typeName = tag.tpe.toString
+    property(s"Cogen[$typeName], arbitrary[$typeName] and its produced values are serializable") = testArbitraryAndCogen[A]
+  }
+
+  registerTest[(String, Int)]
+
+  registerTest[(String, Int, Int)]
+
+  registerTest[List[Int] => List[(String, Int)]]
+
+  property("Buildable[Int, List[Int]] is serializable") = testSerializable(
+    implicitly[Buildable[Int, List[Int]]]
+  )
+
+  registerTest[List[Int]]
+
+  registerTest[List[(String, Int)]]
+
+  registerTest[List[(String, Int)] => List[Int]]
+
+  registerTest[List[(Int, (String, Int))] => List[(String, Int)]]
+
+  registerTest[Set[Int]]
+
+  registerTest[Duration]
+
+  registerTest[Try[Option[Int]]]
+}


### PR DESCRIPTION
Right now, tuple generators (e.g. `Gen[(String, Int)]`) are not serializable. Generated functions that have tuples in the result (e.g. `List[Int] => List[(String, Int)]`) also don't serialize.
This PR adds serializability to the mentioned values. It does so by removing `Function1` which is not serializable and use `flatMap` and `map` to generate `zip` code in `codegen.scala`. A serialization regression test is also included.