### PR TITLE
annotate Prop and Pretty as `@FunctionalInterface`

### DIFF
--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -22,6 +22,7 @@ sealed class PropFromFun(f: Gen.Parameters => Prop.Result) extends Prop {
 }
 
 @Platform.EnableReflectiveInstantiation
+@FunctionalInterface
 sealed abstract class Prop extends Serializable { self =>
 
   import Prop.{Result, True, False, Undecided, provedToTrue, mergeRes}

--- a/src/main/scala/org/scalacheck/util/Pretty.scala
+++ b/src/main/scala/org/scalacheck/util/Pretty.scala
@@ -16,6 +16,7 @@ import org.scalacheck.Test
 import scala.annotation.tailrec
 import scala.math.round
 
+@FunctionalInterface
 sealed trait Pretty extends Serializable {
   def apply(prms: Pretty.Params): String
 


### PR DESCRIPTION
this makes them more convenient to use from Dotty, since Dotty warns on SAM types unless they have this annotation