### PR TITLE
sbt: use slash syntax throughout build.sbt

### DIFF
--- a/examples/scalajs/README.md
+++ b/examples/scalajs/README.md
@@ -17,7 +17,7 @@ setting `scalaJSStage` to `FastOptStage`.  For example, for a project `js` this
 can be set on the command line with:
 
 ```
-set scalaJSStage in js := FastOptStage
+set js / scalaJSStage := FastOptStage
 ```
 
 The following is what you need to add to your `build.sbt` file to make the

--- a/examples/simple-sbt/build.sbt
+++ b/examples/simple-sbt/build.sbt
@@ -4,4 +4,4 @@ scalaVersion := "2.12.10"
 
 libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.2" % "test"
 
-testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-maxSize", "5", "-minSuccessfulTests", "33", "-workers", "1", "-verbosity", "1")
+Test / testOptions += Tests.Argument(TestFrameworks.ScalaCheck, "-maxSize", "5", "-minSuccessfulTests", "33", "-workers", "1", "-verbosity", "1")

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -10,7 +10,7 @@ inThisBuild(
   )
 )
 
-skip in publish := true
+publish / skip := true
 
 lazy val rules = project
   .settings(
@@ -20,19 +20,19 @@ lazy val rules = project
 
 lazy val input = project
   .settings(
-    skip in publish := true,
+    publish / skip := true,
     libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.3",
   )
 
 lazy val output = project
   .settings(
-    skip in publish := true,
+    publish / skip := true,
     libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.3",
   )
 
 lazy val tests = project
   .settings(
-    skip in publish := true,
+    publish / skip := true,
     libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
     compile.in(Compile) :=
       compile.in(Compile).dependsOn(compile.in(input, Compile)).value,

--- a/tools/travis-script.sh
+++ b/tools/travis-script.sh
@@ -9,7 +9,7 @@ else
   TESTS=1000
 fi
 
-sbt_cmd+=("set parallelExecution in ThisBuild := $SBT_PARALLEL")
+sbt_cmd+=("set ThisBuild / parallelExecution := $SBT_PARALLEL")
 
 for t in clean compile "testOnly * -- -s $TESTS -w $WORKERS" mimaReportBinaryIssues package; do
   sbt_cmd+=("$PLATFORM/$t")


### PR DESCRIPTION
this syntax is more pleasant and is considered standard now