### PR TITLE
Fix Gen.pick when used with Gen[_] arguments.

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -289,6 +289,19 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
     }
   }
 
+  property("pick with gen") = forAll { (x: Int, y: Int, rest: List[Int]) =>
+    val lst = x :: y :: rest
+    forAll(choose(-1, 2 * lst.length)) { n =>
+      val gs = rest.map(Gen.const)
+      Try(pick(n, Gen.const(x), Gen.const(y), gs: _*)) match {
+        case Success(g) =>
+          forAll(g) { m => m.length == n && m.forall(lst.contains) }
+        case Failure(_) =>
+          Prop(n < 0 || n > lst.length)
+      }
+    }
+  }
+
   /**
    * Expect:
    * 25% 1, 2, 3

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -946,7 +946,7 @@ object Gen extends GenArities with GenVersionSpecific {
    * The elements are not guaranteed to be permuted in random order.
    */
   def pick[T](n: Int, g1: Gen[T], g2: Gen[T], gn: Gen[T]*): Gen[Seq[T]] =
-    sequence[Seq[T], T](g1 +: g2 +: gn)
+    pick(n, g1 +: g2 +: gn).flatMap(sequence[Seq[T], T](_))
 
   /** Takes a function and returns a generator that generates arbitrary
    *  results of that function by feeding it with arbitrarily generated input


### PR DESCRIPTION
Previously, when called with generators Gen.pick could return collections of
any length, when the API promises that they are length `n`.

    // should only generate Seq(0,1), Seq(0,2), or Seq(1,2).
    val g = Gen.pick(2, Gen.const(0), Gen.const(1), Gen.const(2))

We didn't have a test for this variant of Gen, which explains why we didn't
detect this breakage.