### PR TITLE
Avoid filtering in nonEmptyBuildableOf.

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -826,7 +826,8 @@ object Gen extends GenArities with GenVersionSpecific {
   def nonEmptyBuildableOf[C,T](g: Gen[T])(implicit
     evb: Buildable[T,C], evt: C => Traversable[T]
   ): Gen[C] =
-    buildableOf(g)(evb, evt).suchThat(c => evt(c).size > 0)
+    sized(s => choose(1, Integer.max(s, 1)))
+      .flatMap(n => buildableOfN(n, g)(evb, evt))
 
   /** A convenience method for calling `buildableOfN[C[T],T](n,g)`. */
   def containerOfN[C[_],T](n: Int, g: Gen[T])(implicit


### PR DESCRIPTION
Previously we used the standard buildableOf and just filtered out empty
collections. However, given that the underlying methods support a size
parameter it's just as easy to inline buildableOf's implementation and
start the minimum size at 1, not 0.

Fixes #708