### PR TITLE
Integer.max not needed in Gen.buildableOf

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -815,7 +815,7 @@ object Gen extends GenArities with GenVersionSpecific {
   def buildableOf[C,T](g: Gen[T])(implicit
     evb: Buildable[T,C], evt: C => Traversable[T]
   ): Gen[C] =
-    sized(s => choose(0, Integer.max(s, 0)))
+    sized(s => choose(0, s))
       .flatMap(n => buildableOfN(n, g)(evb, evt))
 
   /** Generates a non-empty container of any Traversable type for which there


### PR DESCRIPTION
I believe `Gen.sized` is always non-negative, so this check isn't necessary.