### PR TITLE
Improve integer shrinking

### DIFF
--- a/src/test/scala/org/scalacheck/ShrinkSpecification.scala
+++ b/src/test/scala/org/scalacheck/ShrinkSpecification.scala
@@ -143,41 +143,42 @@ object ShrinkSpecification extends Properties("Shrink") {
    *
    * Also, for each shrinkee the stream of shrunk values must be finite.  We
    * can empirically determine the length of the longest possible stream for a
-   * given type.  Usually this involves using the type's MinValue.
+   * given type.  Usually this involves using the type's MinValue in the case
+   * of fractional types, or MinValue + 1 for integral types.
    *
-   * For example, shrink(Byte.MinValue).toList gives us 15 values:
+   * For example, shrink(Byte.MinValue + 1).toList gives us 8 values:
    *
-   *   List(-64, 64, -32, 32, -16, 16, -8, 8, -4, 4, -2, 2, -1, 1, 0)
+   *   List(127, 0, -64, -96, -112, -120, -124, -126)
    *
    * Similarly, shrink(Double.MinValue).size gives us 2081.
    */
 
   property("shrink[Byte].nonEmpty") =
-    forAllNoShrink((n: Byte) => Shrink.shrink(n).drop(15).isEmpty)
+    forAllNoShrink((n: Byte) => Shrink.shrink(n).drop(8).isEmpty)
 
   property("shrink[Char].nonEmpty") =
     forAllNoShrink((n: Char) => Shrink.shrink(n).drop(16).isEmpty)
 
   property("shrink[Short].nonEmpty") =
-    forAllNoShrink((n: Short) => Shrink.shrink(n).drop(31).isEmpty)
+    forAllNoShrink((n: Short) => Shrink.shrink(n).drop(16).isEmpty)
 
   property("shrink[Int].nonEmpty") =
-    forAllNoShrink((n: Int) => Shrink.shrink(n).drop(63).isEmpty)
+    forAllNoShrink((n: Int) => Shrink.shrink(n).drop(32).isEmpty)
 
   property("shrink[Long].nonEmpty") =
-    forAllNoShrink((n: Long) => Shrink.shrink(n).drop(127).isEmpty)
+    forAllNoShrink((n: Long) => Shrink.shrink(n).drop(64).isEmpty)
 
   property("shrink[Float].nonEmpty") =
-    forAllNoShrink((n: Float) => Shrink.shrink(n).drop(2081).isEmpty)
+    forAllNoShrink((n: Float) => Shrink.shrink(n).drop(289).isEmpty)
 
   property("shrink[Double].nonEmpty") =
     forAllNoShrink((n: Double) => Shrink.shrink(n).drop(2081).isEmpty)
 
   property("shrink[FiniteDuration].nonEmpty") =
-    forAllNoShrink((n: FiniteDuration) => Shrink.shrink(n).drop(2081).isEmpty)
+    forAllNoShrink((n: FiniteDuration) => Shrink.shrink(n).drop(64).isEmpty)
 
   property("shrink[Duration].nonEmpty") =
-    forAllNoShrink((n: Duration) => Shrink.shrink(n).drop(2081).isEmpty)
+    forAllNoShrink((n: Duration) => Shrink.shrink(n).drop(64).isEmpty)
 
   // make sure we handle sentinel values appropriately for Float/Double.
 


### PR DESCRIPTION
This is my implementation of #735.

I have included some extra tests of shrinking, which prevents regressions of #244 more thoroughly. I added them mainly so I could be sure my new shrinker works as desired.

I recommend you read my code changes before reading the following side notes:

I think the tests on the form `property("shrink[Byte]") = forAll { (n: Byte) => !shrink(n).contains(n) }` are superfluous (given my acyclic tests), and I'll happily write a commit which deletes them if you like. Otherwise, I think they should use `forAllNoShrink`, otherwise shrinking will go into an infinite loop when they fail. In general, I think tests of shrinkers should use `forAllNoShrink` in almost all circumstances: if the shrinker is buggy, how interested are you in the minimal gold-in-garbage-out counterexample it produces? I guess you could shrink with a different shrinker, but will you test the second shrinker, and the third, etc.?

The tests on the form `property("shrink[Byte] != 0") = forAll { (n: Byte) => (n != 0) ==> shrinkClosure(n).contains(0) }` also caught my attention: `shrinkClosure` looks dangerous to call on buggy infinite-regress shrinkers. A safer test which proves the same thing, for integral types, is this: `forAllNoShrink { (n: T) => (n == 0) == shrink(n).isEmpty }`. Assuming the shrink function is a strict partial order (i.e. the tests I've added cannot fail) and also assuming the above test succeeds, all values except zero shrink to something, and since shrinking is acyclic (and thus finite for finitely inhabited types), all shrinking processes transitively shrink to zero. But since we only do a single shrink in the test I'm suggesting, it will not hang if shrinking is cyclic. It might incorrectly succeed, or fail to prove what I think you want, but in that case the "x is acyclic" tests will fail, so you will know there is something to correct.

I'd like to hear your thoughts about why you prefer `property("shrink[Byte] != 0") = forAll { (n: Byte) => (n != 0) ==> shrinkClosure(n).contains(0) }` to `forAllNoShrink { (n: T) => (n == 0) == shrink(n).isEmpty }`, if that is indeed the case, or else whether you'd like me to make the change.