### PR TITLE
Scala Native 0.4.0

### DIFF
--- a/tools/travis-script.sh
+++ b/tools/travis-script.sh
@@ -9,7 +9,7 @@ else
   TESTS=1000
 fi
 
-for t in clean compile "testOnly * -- -s $TESTS -w $WORKERS" mimaReportBinaryIssues package; do
+for t in clean compile "testOnly * -- \"-s $TESTS -w $WORKERS\"" mimaReportBinaryIssues package; do
   sbt_cmd+=("$PLATFORM/$t")
 done
 


### PR DESCRIPTION
Patch to #751 to make it compile, it still crashes due to reflective instantiation of the test classes.

<details>
<summary>Stack trace</summary>

[error] scala.scalanative.testinterface.common.RPCCore$RPCException: java.lang.Exception: loadable module not found: org.scalacheck.NoPropertyNestingSpecification
[error]         at scala.scalanative.testinterface.common.RPCCore.$anonfun$handleMessage$4(RPCCore.scala:66)
[error]         at scala.Option.foreach(Option.scala:407)
[error]         at scala.scalanative.testinterface.common.RPCCore.$anonfun$handleMessage$1(RPCCore.scala:64)
[error]         at scala.scalanative.testinterface.common.RPCCore.$anonfun$handleMessage$1$adapted(RPCCore.scala:43)
[error]         at scala.scalanative.testinterface.common.Serializer$.withInputStream(Serializer.scala:51)
[error]         at scala.scalanative.testinterface.common.RPCCore.handleMessage(RPCCore.scala:43)
[error]         at scala.scalanative.testinterface.NativeRunnerRPC.$anonfun$runner$1(NativeRunnerRPC.scala:29)
[error]         at scala.scalanative.testinterface.NativeRunnerRPC.$anonfun$runner$1$adapted(NativeRunnerRPC.scala:29)
[error]         at scala.scalanative.testinterface.ComRunner$$anon$1.run(ComRunner.scala:60)
[error] Caused by: java.lang.Exception: loadable module not found: org.scalacheck.NoPropertyNestingSpecification
[error]         at java.lang.Throwable.fillInStackTrace(Unknown Source)
[error]         at org.scalacheck.Platform$.$anonfun$loadModule$1(Unknown Source)
[error]         at org.scalacheck.Platform$$$Lambda$1.apply(Unknown Source)
[error]         at scala.Option.getOrElse(Unknown Source)
[error]         at org.scalacheck.Platform$.loadModule(Unknown Source)
[error]         at org.scalacheck.ScalaCheckRunner.rootTask(Unknown Source)


</details>

I'm a bit puzzled, since it looks like the test classes seem be erased at runtime, despite their superclass `Properties` being annotated with `@EnableReflectiveInstantiation`