### PR TITLE
Add Cogen Instance For UUID

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/CogenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/CogenSpecification.scala
@@ -20,6 +20,8 @@ import ScalaVersionSpecific._
 import scala.util.Try
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
+import java.util.UUID
+
 object CogenSpecification extends Properties("Cogen") {
 
   // We need a customized definition of equality for some of our tests.
@@ -162,4 +164,5 @@ object CogenSpecification extends Properties("Cogen") {
   include(cogenLaws[Seq[Int]], "cogenSeq.")
   include(cogenLaws[Duration], "cogenDuration.")
   include(cogenLaws[FiniteDuration], "cogenFiniteDuration.")
+  include(cogenLaws[UUID], "cogenUUID.")
 }

--- a/src/main/scala/org/scalacheck/Cogen.scala
+++ b/src/main/scala/org/scalacheck/Cogen.scala
@@ -15,6 +15,7 @@ import scala.collection.immutable.BitSet
 import scala.util.{Failure, Success, Try}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import java.math.BigInteger
+import java.util.UUID
 import rng.Seed
 
 sealed trait Cogen[T] extends Serializable {
@@ -157,6 +158,11 @@ object Cogen extends CogenArities with CogenLowPriority with CogenVersionSpecifi
 
   implicit def cogenPartialFunction[A: Arbitrary, B: Cogen]: Cogen[PartialFunction[A, B]] =
     Cogen[A => Option[B]].contramap(_.lift)
+
+  implicit val cogenUUID: Cogen[UUID] =
+    Cogen[(Long, Long)].contramap(value =>
+      (value.getLeastSignificantBits, value.getMostSignificantBits)
+    )
 
   def perturbPair[A, B](seed: Seed, ab: (A, B))(implicit A: Cogen[A], B: Cogen[B]): Seed =
     B.perturb(A.perturb(seed, ab._1), ab._2)


### PR DESCRIPTION
We already have an `Arbitrary` instance for it and it is really nice to have the `Cogen` instance for law checking with Discipline.