### PR TITLE
Fix typos

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -608,7 +608,7 @@ object Gen extends GenArities with GenVersionSpecific {
 
 
   /**
-   * A fixed point generator. This is useful for making recusive structures
+   * A fixed point generator. This is useful for making recursive structures
    * e.g.
    *
    * Gen.recursive[List[Int]] { recurse =>
@@ -1288,7 +1288,7 @@ object Gen extends GenArities with GenVersionSpecific {
 
     // We want to be sure we always initialize the calendar's time. By
     // default, Calendar.getInstance uses the system time. We always
-    // overwrite it with a determinisitcally-generated time to be sure
+    // overwrite it with a deterministically-generated time to be sure
     // that calendar generation is also deterministic.
     //
     // We limit the time (in milliseconds) because extreme values will

--- a/src/test/scala/org/scalacheck/util/PrettySpecification.scala
+++ b/src/test/scala/org/scalacheck/util/PrettySpecification.scala
@@ -42,7 +42,7 @@ object PrettySpecification extends Properties("Pretty") {
       lines.forall(s => s.length <= length)
     }
 
-  property("break is reversable") =
+  property("break is reversible") =
     Prop.forAll { (input: String, lead: String, x: Int) =>
       val length = lead.length + (x & 0xff) + 1
       val res = Pretty.break(input, lead, length)


### PR DESCRIPTION
Found/fixed three typos, two in doc strings (and therefore non-semantic) and one in a `property` string. If the latter breaks anything, happy to back it out.