### PR TITLE
Fix Off By One Error In JavaTimeChoose

### DIFF
--- a/jvm/src/main/scala/org/scalacheck/time/JavaTimeChoose.scala
+++ b/jvm/src/main/scala/org/scalacheck/time/JavaTimeChoose.scala
@@ -27,7 +27,7 @@ private[scalacheck] trait JavaTimeChoose {
                 if(seconds == minSeconds) {
                   min.getNano
                 } else {
-                  1
+                  0
                 }
               val maxNanos: Int =
                 if (seconds == maxSeconds) {
@@ -57,7 +57,7 @@ private[scalacheck] trait JavaTimeChoose {
                 if (epochSecond == min.getEpochSecond) {
                   min.getNano
                 } else {
-                  1
+                  0
                 }
               val maxNano: Int =
                 if (epochSecond == max.getEpochSecond) {

--- a/jvm/src/test/scala/org/scalacheck/time/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/time/GenSpecification.scala
@@ -6,16 +6,21 @@ import org.scalacheck.Prop._
 import org.scalacheck.Shrink._
 import org.scalacheck._
 import scala.util._
+import java.time.temporal.TemporalUnit
+import java.time.temporal.ChronoUnit
 
 object GenSpecification extends Properties("java.time Gen") with OrphanInstances {
 
-  private[this] def chooseProp[A](implicit C: Choose[A], A: Arbitrary[A], O: Ordering[A]): Prop = {
-    import O.mkOrderingOps
+  private[this] def chooseProp[A](implicit C: Choose[A], A: Arbitrary[A], O: Ordering[A]): Prop =
     forAll { (l: A, h: A) =>
-      Try(choose(l, h)) match {
+      checkChoose(l, h)
+    }
+
+  private[this] def checkChoose[A](l: A, h: A)(implicit C: Choose[A], O: Ordering[A]): Prop = {
+    import O.mkOrderingOps
+    Try(choose(l, h)) match {
         case Success(g) => forAll(g) { x => l <= x && x <= h }
         case Failure(_) => Prop(l > h)
-      }
     }
   }
 
@@ -44,4 +49,28 @@ object GenSpecification extends Properties("java.time Gen") with OrphanInstances
   property("choose-yearMonth") = chooseProp[YearMonth]
 
   property("choose-zonedDateTime") = chooseProp[ZonedDateTime]
+
+  // https://github.com/typelevel/scalacheck/issues/762
+  property("handle-min-nanos-duration") = forAllNoShrink{(min: Duration) =>
+    // At most one second larger, with 0 in nanos.
+    val max: Duration =
+      min.plusSeconds(1L).withNanos(0)
+
+    // We either select the min second value or the max second value. In the
+    // case where we select the max second value the valid nano range is [0,0]
+    // (was incorrectly [1,0] in the past which caused an exception).
+    checkChoose(min, max)
+  }
+
+  // https://github.com/typelevel/scalacheck/issues/762
+  property("handle-min-nanos-instant") = forAllNoShrink{(min: Instant) =>
+    // At most one second later, with 0 in nanos.
+    val max: Instant =
+      min.plusSeconds(1L).truncatedTo(ChronoUnit.NANOS)
+
+    // We either select the min second value or the max second value. In the
+    // case where we select the max second value the valid nano range is [0,0]
+    // (was incorrectly [1,0] in the past which caused an exception).
+    checkChoose(min, max)
+  }
 }


### PR DESCRIPTION
The minimum value of nanoseconds for both Duration and Instant should be 0, unless the second value == the minimum bound's second value. It was incorrectly encoded as 1.

Fixes #762