### PR TITLE
Add Gen.bool

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -462,6 +462,10 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
     }
   }
 
+  property("bool") = forAll(bool) { b =>
+    b || true
+  }
+
   // BigDecimal generation is tricky; just ensure that the generator gives
   // its constructor valid values.
   property("BigDecimal") = forAll { (_: BigDecimal) => true }

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -1126,6 +1126,9 @@ object Gen extends GenArities with GenVersionSpecific {
       r(Some(x < chance), s1)
     }
 
+  /** Generates a Boolean. */
+  def bool: Gen[Boolean] = prob(0.5)
+
   /**
    * Generates Double values according to the given gaussian
    * distribution, specified by its mean and standard deviation.


### PR DESCRIPTION
The `Gen` object currently doesn't have a generator for Booleans that's simple and easy to find.

This adds a boolean generator to the `Gen` object called `bool`.