### PR TITLE
Add Arbitrary[Symbol]

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
@@ -23,6 +23,16 @@ object ArbitrarySpecification extends Properties("Arbitrary") {
   property("arbOption coverage") =
     exists(genOptionUnits) { case (a, b) => a.isDefined != b.isDefined }
 
+  property("arbString") =
+    Prop.forAll { (s: String) =>
+      s ne new String(s)
+    }
+
+  property("arbSymbol") =
+    Prop.forAll { (s: Symbol) =>
+      s eq Symbol(s.name)
+    }
+
   case class Recur(opt: Option[Recur])
 
   property("arbitrary[Recur].passes") = {

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -148,6 +148,10 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   implicit lazy val arbString: Arbitrary[String] =
     Arbitrary(Gen.stringOf(arbitrary[Char]))
 
+  /** Arbitrary instance of Symbol */
+  implicit lazy val arbSymbol: Arbitrary[Symbol] =
+    Arbitrary(arbitrary[String].map(Symbol(_)))
+
   /** Arbitrary instance of Date */
   implicit lazy val arbDate: Arbitrary[java.util.Date] =
     Arbitrary(Gen.calendar.map(_.getTime))


### PR DESCRIPTION
Fixes #243.

Quoted symbol is deprecated in Scala 2.13, but the Symbol class is still available.