### PR TITLE
Fix stack overflow with Prop.all

### DIFF
--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -427,13 +427,15 @@ object Prop {
 
   /** Combines properties into one, which is true if and only if all the
    *  properties are true */
-  def all(ps: Prop*): Prop =
-    ps.foldLeft(proved)(_ && _)
+  def all(ps: Prop*) =
+    if (ps.isEmpty) proved
+    else Prop(prms => ps.map(p => p(prms)).reduceLeft(_ && _))
 
   /** Combines properties into one, which is true if at least one of the
    *  properties is true */
-  def atLeastOne(ps: Prop*): Prop =
-    ps.foldLeft(falsified)(_ || _)
+  def atLeastOne(ps: Prop*) =
+    if (ps.isEmpty) falsified
+    else Prop(prms => ps.map(p => p(prms)).reduceLeft(_ || _))
 
   /** A property that holds if at least one of the given generators
    *  fails generating a value */

--- a/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -137,10 +137,14 @@ object PropSpecification extends Properties("Prop") {
     exception(e)(prms).status == Exception(e)
   }
 
-  property("all") = forAll(Gen.nonEmptyListOf(const(proved)))(l => all(l:_*))
+  property("all") = {
+    val props: List[Prop] = List.fill(1000000)(proved)
+    all(props: _*)
+  }
 
-  property("atLeastOne") = forAll(Gen.nonEmptyListOf(const(proved))) { l =>
-    atLeastOne(l:_*)
+  property("atLeastOne") = {
+    val props: List[Prop] = List.fill(1000000)(proved)
+    atLeastOne(props: _*)
   }
 
   property("throws") = throws(classOf[java.lang.Exception]) {


### PR DESCRIPTION
Revert the refactoring done to Prop.all and Prop.atLeastOne in #531.

Fixes #748.
