### PR TITLE
Verbosity level for pretty-printing proofs

### DIFF
--- a/src/main/scala/org/scalacheck/util/Pretty.scala
+++ b/src/main/scala/org/scalacheck/util/Pretty.scala
@@ -160,6 +160,7 @@ object Pretty {
       if(ls.isEmpty) ""
       else "> Labels of failing property: " / ls.mkString("\n")
     val s = res.status match {
+      case Test.Proved(args) if(prms.verbosity <= 1) => "OK, proved property."
       case Test.Proved(args) => "OK, proved property."/prettyArgs(args)(prms)
       case Test.Passed => "OK, passed "+res.succeeded+" tests."
       case Test.Failed(args, l) =>


### PR DESCRIPTION
Don't pretty-print by default, only when verbosity is 2 or higher.

In SBT, this would be accomplished with:

    > testOnly org.scalacheck.PropSpecification -- -v2

Proofs that are run a against large value currently flood the screen or take a long time to run.