### PR TITLE
ScalaCheck follows semver since 1.14.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,8 @@ def env(name: String): Option[String] =
 
 val isRelease = env("IS_RELEASE").exists(_ == "true")
 
+ThisBuild / versionScheme := Some("pvp")
+
 lazy val sharedSettings = MimaSettings.settings ++ Seq(
 
   name := "scalacheck",


### PR DESCRIPTION
Set PVP to avoid false negatives, as pointed out by @julienrf.