### PR TITLE
Only run bench once in the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.0-RC1, 3.0.0-RC2, 2.12.13, 2.13.5]
+        scala: [2.13.5]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -162,5 +162,5 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Run dubious benchmark suite
+      - name: Build benchmark suite
         run: 'sbt ++${{ matrix.scala }} ''bench/jmh:run -p genSize=0 -p seedCount=0 -bs 1 -wi 0 -i 1 -f 0 -t 1 -r 0 org.scalacheck.bench.GenBench'''

--- a/build.sbt
+++ b/build.sbt
@@ -75,9 +75,9 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
     githubWorkflowJobSetup.value.toList ::: List(
       WorkflowStep.Sbt(
         List("bench/jmh:run -p genSize=0 -p seedCount=0 -bs 1 -wi 0 -i 1 -f 0 -t 1 -r 0 org.scalacheck.bench.GenBench"),
-        name = Some("Run dubious benchmark suite"))),
+        name = Some("Build benchmark suite"))),
     javas = List(Java8),
-    scalas = crossScalaVersions.value.toList))
+    scalas = List(crossScalaVersions.value.last)))
 
 lazy val versionNumber = "1.15.4"
 


### PR DESCRIPTION
Pare down the build.  It's not necessary to run across Scala versions.  

Running against the latest Scala is what we did in the old Travis build, see #609.