### PR TITLE
Drop doc setting in native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -250,7 +250,6 @@ lazy val jvm = project.in(file("jvm"))
 lazy val native = project.in(file("native"))
   .settings(sharedSettings: _*)
   .settings(
-    Compile / doc := (jvm / Compile / doc).value,
     scalaVersion := Scala212,
     crossScalaVersions := Seq(Scala212, Scala213),
     // TODO: re-enable MiMa for native once published


### PR DESCRIPTION
Saw this in the Native build and not sure what it does.  

```scala
Compile / doc := (jvm / Compile / doc).value
```

Maybe it used to do something, but is no longer necessary?