### PR TITLE
Scala 3.0 syntax nits

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -20,7 +20,7 @@ import scala.util.{Try, Success, Failure}
 object GenSpecification extends Properties("Gen") with GenSpecificationVersionSpecific {
 
   implicit val arbSeed: Arbitrary[Seed] = Arbitrary(
-    arbitrary[Long] flatMap Seed.apply
+    arbitrary[Long].flatMap(Seed.apply)
   )
 
   property("pureApply #300") = {

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -63,7 +63,7 @@ object Arbitrary extends ArbitraryLowPriority with ArbitraryArities with time.Ja
 
   /** Arbitrary instance of the Function0 type. */
   implicit def arbFunction0[T](implicit a: Arbitrary[T]): Arbitrary[() => T] =
-  Arbitrary(arbitrary[T] map (() => _))
+  Arbitrary(arbitrary[T].map(() => _))
 }
 
 /** separate trait to have same priority as ArbitraryArities */
@@ -259,7 +259,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
       arbitrary[Byte], arbitrary[Short], arbitrary[Int], arbitrary[Long],
       arbitrary[Float], arbitrary[Double]
     )
-    Arbitrary(gen map (_.asInstanceOf[Number]))
+    Arbitrary(gen.map(_.asInstanceOf[Number]))
     // XXX TODO - restore BigInt and BigDecimal
     // Arbitrary(oneOf(arbBigInt.arbitrary :: (arbs map (_.arbitrary) map toNumber) : _*))
   }
@@ -313,7 +313,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   /** Arbitrary instance of gen params */
   implicit lazy val arbGenParams: Arbitrary[Gen.Parameters] =
     Arbitrary(for {
-      sz <- arbitrary[Int] suchThat (_ >= 0)
+      sz <- arbitrary[Int].suchThat(_ >= 0)
     } yield Gen.Parameters.default.withSize(sz))
 
 
@@ -330,7 +330,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   /** Arbitrary instance of [[org.scalacheck.Gen]] */
   implicit def arbGen[T](implicit a: Arbitrary[T]): Arbitrary[Gen[T]] =
     Arbitrary(frequency(
-      (5, arbitrary[T] map (const(_))),
+      (5, arbitrary[T].map(const(_))),
       (1, Gen.fail)
     ))
 

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -708,7 +708,7 @@ object Gen extends GenArities with GenVersionSpecific {
 
     implicit object chooseBigInteger extends Choose[BigInteger] {
       def choose(low: BigInteger, high: BigInteger): Gen[BigInteger] =
-        (low compareTo high) match {
+        (low.compareTo(high)) match {
           case n if n > 0 => throw new IllegalBoundsError(low, high)
           case 0 => Gen.const(low)
           case _ => /* n < 0 */
@@ -767,7 +767,7 @@ object Gen extends GenArities with GenVersionSpecific {
     private[this] def chooseJavaBigDecimalScale(minScale: Int): Choose[JavaDecimal] =
       new Choose[JavaDecimal] {
         def choose(low: JavaDecimal, high: JavaDecimal): Gen[JavaDecimal] =
-        (low compareTo high) match {
+        (low.compareTo(high)) match {
           case n if n > 0 => throw new IllegalBoundsError(low, high)
           case 0 => Gen.const(low)
           case _ => /* n < 0 */
@@ -1146,7 +1146,7 @@ object Gen extends GenArities with GenVersionSpecific {
    *  results of that function by feeding it with arbitrarily generated input
    *  parameters. */
   def resultOf[T,R0](f: T => R0)(implicit a: Arbitrary[T]): Gen[R0] =
-    arbitrary[T] map f
+    arbitrary[T].map(f)
 
   /** Creates a Function0 generator. */
   def function0[A](g: Gen[A]): Gen[() => A] =
@@ -1445,7 +1445,7 @@ object Gen extends GenArities with GenVersionSpecific {
 
   /** Generates negative numbers of uniform distribution, with an
    *  lower bound of the negated generation size parameter. */
-  def negNum[T](implicit num: Numeric[T], c: Choose[T]): Gen[T] = posNum.map(num.negate _)
+  def negNum[T](implicit num: Numeric[T], c: Choose[T]): Gen[T] = posNum.map(num.negate(_))
 
   /** Generates numbers within the given inclusive range, with
    *  extra weight on zero, +/- unity, both extremities, and any special

--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -63,7 +63,7 @@ class Properties(val name: String) {
   def check(prms: Test.Parameters = Test.Parameters.default): Unit = {
     val params = overrideParameters(prms)
     Test.checkProperties(
-      params.withTestCallback(ConsoleReporter(1) chain params.testCallback), this
+      params.withTestCallback(ConsoleReporter(1).chain(params.testCallback)), this
     )
   }
 

--- a/src/main/scala/org/scalacheck/commands/Commands.scala
+++ b/src/main/scala/org/scalacheck/commands/Commands.scala
@@ -373,7 +373,7 @@ trait Commands {
       l.foldLeft(const((s,Nil:Commands))) { case (g,()) =>
         for {
           (s0,cs) <- g
-          c <- genCommand(s0) suchThat (_.preCondition(s0))
+          c <- genCommand(s0).suchThat(_.preCondition(s0))
         } yield (c.nextState(s0), cs :+ c)
       }
     }

--- a/src/test/scala/org/scalacheck/NoPropertyNestingSpecification.scala
+++ b/src/test/scala/org/scalacheck/NoPropertyNestingSpecification.scala
@@ -24,7 +24,7 @@ object NoPropertyNestingSpecification extends Properties("Properties.no nesting"
     results match {
       case collection.Seq(res) => res.status match {
         case Prop.Exception(e: IllegalStateException) =>
-          if (e.getMessage contains "nest") thrown = true
+          if (e.getMessage.contains("nest")) thrown = true
           else throw new Exception("exception message did not reference nesting")
         case _ => throw new Exception("did not get IllegalStateException")
       }

--- a/src/test/scala/org/scalacheck/ShrinkSpecification.scala
+++ b/src/test/scala/org/scalacheck/ShrinkSpecification.scala
@@ -104,9 +104,9 @@ object ShrinkSpecification extends Properties("Shrink") {
 
   property("suchThat") = {
     implicit def shrinkEvenLength[A]: Shrink[List[A]] =
-      Shrink.shrinkContainer[List,A].suchThat(evenLength _)
+      Shrink.shrinkContainer[List,A].suchThat(evenLength(_))
     val genEvenLengthLists =
-      Gen.containerOf[List,Int](Arbitrary.arbitrary[Int]).suchThat(evenLength _)
+      Gen.containerOf[List,Int](Arbitrary.arbitrary[Int]).suchThat(evenLength(_))
     forAll(genEvenLengthLists) { (l: List[Int]) =>
       evenLength(l)
     }
@@ -114,11 +114,11 @@ object ShrinkSpecification extends Properties("Shrink") {
 
   def evenLength(value: List[_]) = value.length % 2 == 0
   def shrinkEvenLength[A]: Shrink[List[A]] =
-    Shrink.shrinkContainer[List,A].suchThat(evenLength _)
+    Shrink.shrinkContainer[List,A].suchThat(evenLength(_))
 
   property("shrink[List[Int].suchThat") = {
     forAll { (l: List[Int]) =>
-      shrink(l)(shrinkEvenLength).forall(evenLength _)
+      shrink(l)(shrinkEvenLength).forall(evenLength(_))
     }
   }
 


### PR DESCRIPTION
These are syntax changes that Scala 3.0 suggests when setting `-source:future`.  

There are a lot more suggestions, but these are the ones we can entertain without breaking 2.12 and 2.13 builds.