### PR TITLE
Adds Discord badge

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,6 @@
 # ScalaCheck
 
+[![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/wQB9Xu422S)
 [![Join the chat at https://gitter.im/scalacheck/Lobby](https://badges.gitter.im/scalacheck/Lobby.svg)](https://gitter.im/scalacheck/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Continuous Integration](https://github.com/typelevel/scalacheck/actions/workflows/ci.yml/badge.svg)](https://github.com/typelevel/scalacheck/actions/workflows/ci.yml)
 


### PR DESCRIPTION
Making the Discord support channel more visible by adding a badge with a badge that links to #scalacheck and that never expires :)

This is how it looks like:

![Screen Shot 2021-05-14 at 00 09 57](https://user-images.githubusercontent.com/33580722/118193945-d9d21180-b448-11eb-9efd-2ed4b12357a6.png)
