### PR TITLE
Add badge to README showing supported versions of Scala

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,6 +3,8 @@
 [![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/wQB9Xu422S)
 [![Join the chat at https://gitter.im/scalacheck/Lobby](https://badges.gitter.im/scalacheck/Lobby.svg)](https://gitter.im/scalacheck/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Continuous Integration](https://github.com/typelevel/scalacheck/actions/workflows/ci.yml/badge.svg)](https://github.com/typelevel/scalacheck/actions/workflows/ci.yml)
+[![scalacheck Scala version support](https://index.scala-lang.org/typelevel/scalacheck/scalacheck/latest-by-scala-version.svg)](https://index.scala-lang.org/typelevel/scalacheck/scalacheck)
+
 
 ScalaCheck is a library written in [Scala](http://www.scala-lang.org/) and
 used for automated property-based testing of Scala or Java programs.


### PR DESCRIPTION
This PR adds a badge to the README showing which versions of the artifact support what versions of Scala. At the time of writing, the badge says:

```
scalacheck 1.15.4 (Scala 3.x, 2.13, 2.12), 1.15.2 (Scala 2.11), 1.14.3 (Scala 2.10)
```
[![scalacheck Scala version support](https://index.scala-lang.org/typelevel/scalacheck/scalacheck/latest-by-scala-version.svg)](https://index.scala-lang.org/typelevel/scalacheck/scalacheck)

More details on the badge format here: https://github.com/scalacenter/scaladex/pull/660