### PR TITLE
Fix Arbitrary[Year] instance max value

### DIFF
--- a/jvm/src/main/scala/org/scalacheck/time/JavaTimeArbitrary.scala
+++ b/jvm/src/main/scala/org/scalacheck/time/JavaTimeArbitrary.scala
@@ -42,7 +42,7 @@ private[scalacheck] trait JavaTimeArbitrary {
   // Year
 
   implicit final lazy val arbYear: Arbitrary[Year] =
-    Arbitrary(Gen.choose(Year.of(Year.MIN_VALUE), Year.of(Year.MIN_VALUE)))
+    Arbitrary(Gen.choose(Year.of(Year.MIN_VALUE), Year.of(Year.MAX_VALUE)))
 
   // LocalDate
 


### PR DESCRIPTION
Caused a very narrow range of inputs in some tests I was writing 😄 