### PR TITLE
Fix Arbitrary[Char] generates 0xFFFE (not a character in Unicode)

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
@@ -9,9 +9,10 @@
 
 package org.scalacheck
 
+import java.util.concurrent.TimeUnit
+
 import Prop._
 import Arbitrary._
-import java.util.concurrent.TimeUnit
 
 object ArbitrarySpecification extends Properties("Arbitrary") {
   val genOptionUnits =

--- a/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
@@ -23,6 +23,11 @@ object ArbitrarySpecification extends Properties("Arbitrary") {
   property("arbOption coverage") =
     exists(genOptionUnits) { case (a, b) => a.isDefined != b.isDefined }
 
+  property("arbChar") =
+    Prop.forAll { (c: Char) =>
+      0x0000 <= c && c <= 0xD7FF || 0xE000 <= c && c <= 0xFFFD
+    }
+
   property("arbString") =
     Prop.forAll { (s: String) =>
       s ne new String(s)

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -152,8 +152,8 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   implicit lazy val arbChar: Arbitrary[Char] = Arbitrary {
     // valid ranges are [0x0000, 0xD7FF] and [0xE000, 0xFFFD].
     //
-    // ((0xFFFD + 1) - 0xE000) + ((0xD7FF + 1) - 0x0000)
-    choose(0, 63486).map { i =>
+    // ((0xFFFD + 1) - 0xE000) + ((0xD7FF + 1) - 0x0000) - 1
+    choose(0, 63485).map { i =>
       if (i <= 0xD7FF) i.toChar
       else (i + 2048).toChar
     }


### PR DESCRIPTION
## Problem 

Valid Char ranges are [0x0000, 0xD7FF] and [0xE000, 0xFFFD].
But Arbitrary[Char] generates 0xFFFE since  #653.

```scala
scala> (63486 + 2048).toHexString
val res0: String = fffe
```

## Test

I tested with 11e23c7 (only add test for Arbitrary[Char]), it failed.
(This test with default parameters will almost always succeed...)
```
$ sbt 'jvm / Test / console'

scala> import org.scalacheck.Test.Parameters
import org.scalacheck.Test.Parameters

scala> org.scalacheck.ArbitrarySpecification.check(Parameters.default.withMinSuccessfulTests(100000))
+ Arbitrary.arbOption coverage: OK, proved property.
failing seed for Arbitrary.arbChar is a0y7J3eh7ctLsQdJDj0uwLsuqfXp9a0rswkVdkFKxOK=
! Arbitrary.arbChar: Falsified after 1093 passed tests.
> ARG_0: ￾
+ Arbitrary.arbString: OK, passed 100000 tests.
+ Arbitrary.arbSymbol: OK, passed 100000 tests.
+ Arbitrary.arbitrary[Recur].passes: OK, passed 100000 tests.
+ Arbitrary.arbitrary[Recur].throws[StackOverflowError]: OK, proved propert
  y.
+ Arbitrary.arbEnum: OK, proved property.
```

with 902121e (this PR), it succeeded.

```
scala> org.scalacheck.ArbitrarySpecification.check(Parameters.default.withMinSuccessfulTests(100000))
+ Arbitrary.arbOption coverage: OK, proved property.
+ Arbitrary.arbChar: OK, passed 100000 tests.
+ Arbitrary.arbString: OK, passed 100000 tests.
+ Arbitrary.arbSymbol: OK, passed 100000 tests.
+ Arbitrary.arbitrary[Recur].passes: OK, passed 100000 tests.
+ Arbitrary.arbitrary[Recur].throws[StackOverflowError]: OK, proved propert
```