### PR TITLE
Keep the same error type while shrinking

### DIFF
--- a/core/shared/src/main/scala/org/scalacheck/Prop.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Prop.scala
@@ -14,6 +14,7 @@ import language.implicitConversions
 import rng.Seed
 import util.{Pretty, ConsoleReporter}
 import scala.annotation.tailrec
+import scala.util.control.NonFatal
 
 /** Helper class to satisfy ScalaJS compilation. Do not use this directly,
  *  use `Prop.apply` instead. */
@@ -775,9 +776,9 @@ object Prop {
     def getFirstFailure(xs: Stream[T], exceptionFilter: Option[Class[_]]): Either[(T,Result),(T,Result)] = {
       assert(!xs.isEmpty, "Stream cannot be empty")
       val results = xs.map(x => (x, result(x)))
-      results.dropWhile { 
+      results.dropWhile {
         case (_, Result(Exception(e), _, _, _)) => !exceptionFilter.contains(e.getClass)
-        case (_, r) => !r.failure 
+        case (_, r) => !r.failure
       }.headOption match {
         case None => Right(results.head)
         case Some(xr) => Left(xr)
@@ -787,7 +788,7 @@ object Prop {
     def shrinker(x: T, r: Result, shrinks: Int, orig: T): Result = {
       val xs = shrink(x)
       val res = r.addArg(Arg(labels,x,shrinks,orig,pp(x),pp(orig)))
-      val originalException = Some(r.status).collect { case Exception(e) => e.getClass() }
+      val originalException = Some(r.status).collect { case NonFatal(e) => e.getClass() }
       if(xs.isEmpty) res else getFirstFailure(xs, originalException) match {
         case Right((x2,r2)) => res
         case Left((x2,r2)) => shrinker(x2, replOrig(r,r2), shrinks+1, orig)

--- a/core/shared/src/main/scala/org/scalacheck/Prop.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Prop.scala
@@ -772,10 +772,13 @@ object Prop {
     /*
      * Returns the first failed result in Left or success in Right.
      */
-    def getFirstFailure(xs: Stream[T]): Either[(T,Result),(T,Result)] = {
+    def getFirstFailure(xs: Stream[T], exceptionFilter: Option[Class[_]]): Either[(T,Result),(T,Result)] = {
       assert(!xs.isEmpty, "Stream cannot be empty")
       val results = xs.map(x => (x, result(x)))
-      results.dropWhile(!_._2.failure).headOption match {
+      results.dropWhile { 
+        case (_, Result(Exception(e), _, _, _)) => !exceptionFilter.contains(e.getClass)
+        case (_, r) => !r.failure 
+      }.headOption match {
         case None => Right(results.head)
         case Some(xr) => Left(xr)
       }
@@ -784,7 +787,8 @@ object Prop {
     def shrinker(x: T, r: Result, shrinks: Int, orig: T): Result = {
       val xs = shrink(x)
       val res = r.addArg(Arg(labels,x,shrinks,orig,pp(x),pp(orig)))
-      if(xs.isEmpty) res else getFirstFailure(xs) match {
+      val originalException = Some(r.status).collect { case Exception(e) => e.getClass() }
+      if(xs.isEmpty) res else getFirstFailure(xs, originalException) match {
         case Right((x2,r2)) => res
         case Left((x2,r2)) => shrinker(x2, replOrig(r,r2), shrinks+1, orig)
       }


### PR DESCRIPTION
This is a proposal to change the way `Prop` is running the shrinking process, which I think can mitigate #129.

Currently, when scalacheck finds an input that either proves that the property is false or throws an exception it start the shrinking process and find the first input in the list which cause any failure.

My proposal is to change that so that we find the first input in the list which cause **the same failure status as before** (meaning an `Exception` with the same class or a `False`).

Motivation
-----------
The current behaviour might be confusing because scalacheck finds an error and can hide it behind some other error after shrinking. 

As a nice side effect it will mitigate #129 (shrinking disregards any filters on an explicit Gen). This actually what I find more interesting here.

Every time I had a problem with shrinking not respecting the generator constraints, the constraint was to avoid things such as division by 0 or other invalid input. Preventing the shrinking process from changing the type of error would have fixed the problem in every instance.

I took a division by 0 as an example in the tests. Currently a failing test will show and `ArithmeticException` because of the shrinking. With the proposed change it won't because the input `0` would transform the status `False` into an `Exception`.

Limitations
-----------
It does not completely solves #129 when the test throws the same exception for every case (like the first example in the issue). My experience makes me think that this is rarely the case in the real world.

What do you think ?