### PR TITLE
Add pick generator specialized for indexed sequences

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -260,6 +260,30 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
     }
   }
 
+  property("indexedPick") = forAll { (vec: Vector[Int]) =>
+    forAll(choose(-1, 2 * vec.length)) { n =>
+      Try(indexedPick(n, vec)) match {
+        case Success(g) =>
+          forAll(g) { m => m.length == n && m.forall(vec.contains) }
+        case Failure(_) =>
+          Prop(n < 0 || n > vec.length)
+      }
+    }
+  }
+
+  property("indexedPick does not repeat picks") = forAll { (set: Set[Int]) =>
+    forAll(choose(-1, 2 * set.size)) { n =>
+      Try(indexedPick(n, set.toVector)) match {
+        case Success(g) =>
+          forAll(g) { m =>
+            m.toSet.size == n
+          }
+        case Failure(_) =>
+          Prop(n < 0 || n > set.size)
+      }
+    }
+  }
+
   /**
    * Expect:
    * 25% 1, 2, 3

--- a/src/main/scala/org/scalacheck/util/MissingSelector.scala
+++ b/src/main/scala/org/scalacheck/util/MissingSelector.scala
@@ -1,0 +1,70 @@
+package org.scalacheck.util
+
+// Modified red-black order statistic tree to select missing elements.
+private[scalacheck] sealed trait MissingSelector {
+  /** Select (and add) the i-th non-negative integer not present.
+   * @param i
+   * @return The i-th non negative integer not present in the original MissingSelector,
+   *         and a new MissingSelector containing this integer.
+   */
+  def selectAndAdd(i: Int): (Int, MissingSelector)
+  def size: Int
+  def toList(others: List[Int] = List.empty[Int]): List[Int]
+}
+
+private[scalacheck] object MissingSelector {
+  val empty: MissingSelector = Empty
+
+  sealed private trait Color
+  private object B extends Color
+  private object R extends Color
+
+  final private class Inner private(
+    private val color: Color,
+    private val root: Int,
+    private val left: MissingSelector,
+    private val right: MissingSelector,
+    val size: Int
+  ) extends MissingSelector {
+    override def selectAndAdd(i: Int): (Int, MissingSelector) = {
+      val (newI, newTree) = if (i + left.size < root) {
+        val (newI, newLeft) = left.selectAndAdd(i)
+        (newI, Inner(color, root, newLeft, right))
+      }
+      else {
+        val (newI, newRight) = right.selectAndAdd(i + left.size + 1)
+        (newI, Inner(color, root, left, newRight))
+      }
+      (newI, newTree.balance.asBlack)
+    }
+
+    override def toList(others: List[Int]): List[Int] = left.toList(root :: right.toList(others))
+
+    private def balance: Inner = this match {
+      case Inner(B, z, Inner(R, y, Inner(R, x, a, b), c), d) =>
+        Inner(R, y, Inner(B, x, a, b), Inner(B, z, c, d))
+      case Inner(B, z, Inner(R, x, a, Inner(R, y, b, c)), d) =>
+        Inner(R, y, Inner(B, x, a, b), Inner(B, z, c, d))
+      case Inner(B, x, a, Inner(R, z, Inner(R, y, b, c), d)) =>
+        Inner(R, y, Inner(B, x, a, b), Inner(B, z, c, d))
+      case Inner(B, x, a, Inner(R, y, b, Inner(R, z, c, d))) =>
+        Inner(R, y, Inner(B, x, a, b), Inner(B, z, c, d))
+      case _ => this
+    }
+
+    private def asBlack: Inner = if (color == B) this else Inner(B, root, left, right)
+  }
+
+  private object Inner {
+    private[MissingSelector] def apply(color: Color, root: Int, left: MissingSelector, right: MissingSelector): Inner =
+      new Inner(color, root, left, right, left.size + right.size + 1)
+    private def unapply(inner: Inner): Option[(Color, Int, MissingSelector, MissingSelector)] =
+      Some((inner.color, inner.root, inner.left, inner.right))
+  }
+
+  private object Empty extends MissingSelector {
+    override def selectAndAdd(i: Int): (Int, MissingSelector) = (i, Inner(B, i, Empty, Empty))
+    override def size: Int = 0
+    override def toList(others: List[Int]): List[Int] = others
+  }
+}

--- a/src/test/scala/org/scalacheck/util/MissingSelectorSpecification.scala
+++ b/src/test/scala/org/scalacheck/util/MissingSelectorSpecification.scala
@@ -1,0 +1,31 @@
+package org.scalacheck
+package util
+
+import org.scalacheck.{Gen, Properties}
+import org.scalacheck.Prop.forAll
+
+object MissingSelectorSpecification extends Properties("MissingSelector") {
+
+  private val smallIntegerGen: Gen[Int] = Gen.choose(0,1000)
+
+  private val missingSelectorGen: Gen[MissingSelector] = Gen.listOf(smallIntegerGen).map { list =>
+    list.foldLeft(MissingSelector.empty){ case (selector, elem) => selector.selectAndAdd(elem)._2 }
+  }
+
+  property("selectAndAdd adds the selected element to the selector") =
+    forAll(missingSelectorGen) { selector =>
+      forAll(smallIntegerGen) { i =>
+        val (selected, newSelector) = selector.selectAndAdd(i)
+        newSelector.toList().sorted == (selected :: selector.toList()).sorted
+      }
+    }
+
+  property("selectAndAdd selects the i-th missing element") =
+    forAll(missingSelectorGen) { selector =>
+      forAll(smallIntegerGen) { i =>
+        val (selected, _) = selector.selectAndAdd(i)
+        val numNotGreater = selector.toList().filter(_ <= selected).length
+        i + numNotGreater == selected
+      }
+    }
+}


### PR DESCRIPTION
Hi! Would there be interest in a pick generator specialized for IndexedSeqs? When choosing k elements from a sequence with n elements, the idea is to choose an element in the inclusive range [0,n-1], then another one in [0,n-2]... up to [0,n-k]. Then these indices must be translated to the whole range [0,n-1] while avoiding repetitions. For this, one can use a modified version of an order statistic tree that selects the i-th non negative integer not present in the tree.

This should pick k elements in O(k log k) time, using O(k) extra space for the tree. Additionally, the elements should be permuted in random order.

The names are horrible but I couldn't come up with better ones. Any help with that would be appreciated if you think it's worth to add this generator to Scalacheck. What do you think?
