### PR TITLE
Onwards and upwards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.2, 2.12.15, 2.13.8]
+        scala: [3.1.1, 2.12.15, 2.13.8]
         java: [temurin@8, temurin@11]
         project: [rootJS, rootJVM, rootNative]
         workers: [1, 4]
@@ -37,8 +37,6 @@ jobs:
             java: temurin@11
           - project: rootNative
             java: temurin@11
-          - project: rootNative
-            scala: 3.0.2
           - project: rootJS
             workers: 4
           - project: rootNative
@@ -191,32 +189,42 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (3.0.2, rootJS, 1)
+      - name: Download target directories (3.1.1, rootJS, 1)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.0.2-rootJS-1
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.1-rootJS-1
 
-      - name: Inflate target directories (3.0.2, rootJS, 1)
+      - name: Inflate target directories (3.1.1, rootJS, 1)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.0.2, rootJVM, 1)
+      - name: Download target directories (3.1.1, rootJVM, 1)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.0.2-rootJVM-1
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.1-rootJVM-1
 
-      - name: Inflate target directories (3.0.2, rootJVM, 1)
+      - name: Inflate target directories (3.1.1, rootJVM, 1)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.0.2, rootJVM, 1)
+      - name: Download target directories (3.1.1, rootNative, 1)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.0.2-rootJVM-1
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.1-rootNative-1
 
-      - name: Inflate target directories (3.0.2, rootJVM, 1)
+      - name: Inflate target directories (3.1.1, rootNative, 1)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.1.1, rootJVM, 1)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.1-rootJVM-1
+
+      - name: Inflate target directories (3.1.1, rootJVM, 1)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val Scala212 = "2.12.15"
 val Scala213 = "2.13.8"
-val Scala3 = "3.0.2"
+val Scala3 = "3.1.1"
 
 name := "scalacheck"
 ThisBuild / organization := "org.scalacheck"
@@ -23,7 +23,6 @@ ThisBuild / githubWorkflowBuildMatrixAdditions += "workers" -> List("1", "4")
 
 ThisBuild / githubWorkflowBuildMatrixExclusions ++=
   List(
-    MatrixExclude(Map("project" -> "rootNative", "scala" -> Scala3)),
     MatrixExclude(Map("project" -> "rootJS", "workers" -> "4")),
     MatrixExclude(Map("project" -> "rootNative", "workers" -> "4"))
   )
@@ -51,7 +50,7 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
     javas = List(Java8),
     scalas = List((ThisBuild / scalaVersion).value)))
 
-ThisBuild / tlBaseVersion := "1.15"
+ThisBuild / tlBaseVersion := "1.16"
 ThisBuild / tlMimaPreviousVersions ++= Set(
   // manually added because tags are not v-prefixed
   "1.14.0",
@@ -115,7 +114,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.scala-native" %%% "test-interface" % nativeVersion
     ),
     tlVersionIntroduced ++=
-      List("2.12", "2.13").map(_ -> "1.15.2").toMap ++ Map("3" -> "1.15.5")
+      List("2.12", "2.13").map(_ -> "1.15.2").toMap ++ Map("3" -> "1.16.0")
   )
 
 lazy val bench = project.in(file("bench"))


### PR DESCRIPTION
Bumps Scala 3 to 3.1.x and Scalacheck to 1.16.x. Closes https://github.com/typelevel/scalacheck/issues/878. Supersedes https://github.com/typelevel/scalacheck/pull/868.