### PR TITLE
Don't cross-build Native for Scala 3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,11 +113,12 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     tlVersionIntroduced ++= List("2.12", "2.13").map(_ -> "1.14.3").toMap
   )
   .nativeSettings(
+    crossScalaVersions := Seq(Scala212, Scala213),
     libraryDependencies ++= Seq(
       "org.scala-native" %%% "test-interface" % nativeVersion
     ),
     tlVersionIntroduced ++=
-      List("2.12", "2.13").map(_ -> "1.15.2").toMap ++ Map("3" -> "1.15.5")
+      List("2.12", "2.13").map(_ -> "1.15.2").toMap ++ Map("3" -> "1.16.0")
   )
 
 lazy val bench = project.in(file("bench"))


### PR DESCRIPTION
I think this should fix publishing. So would this one:
- https://github.com/typelevel/scalacheck/pull/879