### PR TITLE
[Commands] Fix MatchError when using multiple workers

### DIFF
--- a/core/jvm/src/test/scala/org/scalacheck/commands/CommandsSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/commands/CommandsSpecification.scala
@@ -13,7 +13,15 @@ import org.scalacheck._
 
 object CommandsSpecification extends Properties("Commands") {
 
-  property("commands") = TestCommands.property(threadCount = 4)
+  def prop = TestCommands.property(threadCount = 4)
+  property("commands") = prop
+
+  // `property(...) = prop` evaluates `prop` for each generation, while this will reuse the same value
+  val reusedProp = prop
+  property("commands with prop evaluated just once") = reusedProp
+
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
+    super.overrideParameters(p).withWorkers(2)
 
   object TestCommands extends Commands {
     case class Counter(var n: Int) {

--- a/core/shared/src/main/scala/org/scalacheck/commands/Commands.scala
+++ b/core/shared/src/main/scala/org/scalacheck/commands/Commands.scala
@@ -218,8 +218,8 @@ trait Commands {
     Prop.forAll(actions(threadCount, maxParComb)) { as =>
       try {
         val sutId = suts.synchronized {
-          val initSuts = for((state,None) <- suts.values) yield state
-          val runningSuts = for((_,Some(sut)) <- suts.values) yield sut
+          val initSuts = suts.values.collect { case (state,None) => state }
+          val runningSuts = suts.values.collect { case (_, Some(sut)) => sut }
           if (canCreateNewSut(as.s, initSuts, runningSuts)) {
             val sutId = new AnyRef
             suts += (sutId -> (as.s -> None))
@@ -252,7 +252,7 @@ trait Commands {
             Prop.undecided
         }
       } catch { case e: Throwable =>
-        suts.synchronized { suts.clear }
+        suts.synchronized { suts.clear() }
         throw e
       }
     }


### PR DESCRIPTION
Fixes #893

`for (Some(v) <- Map(...).values) yield v` would throw MatchError as soon as it tries to process a value that doesn't conform to Some(v).

The tests didn't detect this because `property("...") = rhs` was re-evaluating `rhs` each time the property is evaluated, which means that Commands.property() only ran one evaluation at a time (so `suts` would always be empty when we run those for comprehensions).
