### PR TITLE
fix scala 3 compilation errors in user guide examples

### DIFF
--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -86,7 +86,7 @@ Here are some examples of properties defined with help of the
 ```scala
 import org.scalacheck.Prop.forAll
 
-val propReverseList = forAll { l: List[String] => l.reverse.reverse == l }
+val propReverseList = forAll { (l: List[String]) => l.reverse.reverse == l }
 
 val propConcatString = forAll { (s1: String, s2: String) =>
   (s1 + s2).endsWith(s2)
@@ -124,7 +124,7 @@ you can use the implication operator `==>`:
 ```scala
 import org.scalacheck.Prop.{forAll, propBoolean}
 
-val propMakeList = forAll { n: Int =>
+val propMakeList = forAll { (n: Int) =>
   (n >= 0 && n < 10000) ==> (List.fill(n)("").length == n)
 }
 ```
@@ -140,7 +140,7 @@ non-zero will be thrown away:
 ```
 scala> import org.scalacheck.Prop.{forAll, propBoolean}
 
-scala> val propTrivial = forAll { n: Int =>
+scala> val propTrivial = forAll { (n: Int) =>
      |  (n == 0) ==> (n == 0)
      | }
 
@@ -628,7 +628,7 @@ list.
 ```scala
 import org.scalacheck.Prop._
 
-val myProp = forAll { l: List[Int] =>
+val myProp = forAll { (l: List[Int]) =>
   classify(ordered(l), "ordered") {
     classify(l.length > 5, "large", "small") {
       l.reverse.reverse == l


### PR DESCRIPTION
User guide examples have few compilation errors when using Scala 3. For instance [here](https://github.com/typelevel/scalacheck/blob/main/doc/UserGuide.md?plain=1#L89):
```
[error]   |  val propReverseList = forAll { l: List[String] => l.reverse.reverse == l }
[error]   |                                                 ^
[error]   |parentheses are required around the parameter of a lambda
[error]   |This construct can be rewritten automatically under -rewrite -source 3.0-migration.
```
According to [Scala 3 migration guide](https://docs.scala-lang.org/scala3/guides/migration/incompat-syntactic.html#parentheses-around-lambda-parameter)

> When followed by its type, the parameter of a lambda is now required to be enclosed in parentheses.

This PR fixes those errors