### PR TITLE
Add Gen.nonEmptyStringOf

### DIFF
--- a/core/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -146,6 +146,16 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
     }
   }
 
+  property("nonEmptyStringOf") = {
+    val g = Gen.size.flatMap(sz => Gen.oneOf(-sz, sz))
+    forAll(g, Gen.alphaChar) { (sz: Int, c: Char) =>
+      forAllNoShrink(Gen.resize(sz, Gen.nonEmptyStringOf(c))) { (s) =>
+        if (sz > 0) sz >= s.size && s.size >= 1 && s.forall(_ == c)
+        else        s.size == 1
+      }
+    }
+  }
+
   property("oneOf n") = forAll { (l: List[Int]) =>
     Try(oneOf(l)) match {
       case Success(g) => forAll(g)(l.contains)

--- a/core/shared/src/main/scala/org/scalacheck/Gen.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Gen.scala
@@ -1246,6 +1246,10 @@ object Gen extends GenArities with GenVersionSpecific {
       else mkString(n, new StringBuilder(n), gc, p, seed1)
     }
 
+  def nonEmptyStringOf(gc: Gen[Char]): Gen[String] =
+    sized(s => choose(1, Integer.max(s, 1)))
+      .flatMap(n => stringOfN(n, gc))
+
   /** Generates a string that starts with a lower-case alpha character,
    *  and only contains alphanumerical characters */
   val identifier: Gen[String] =


### PR DESCRIPTION
I totally realize that there are a lot of other ways to achieve the same functionality with the existing generators,
but I think it is a quite basic feature and can come handy when someone (me, personally) just needs to "grab and go" a non-empty string. So I believe it would complement the `nonEmptyListOf` and `nonEmptyMap` generators pretty well.