### PR TITLE
Integrate sbt-header (via sbt-typelevel)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         project: [rootJS, rootJVM, rootNative]
         workers: [1, 4]
         exclude:
+          - scala: 3.2.2
+            java: temurin@11
+          - scala: 2.12.17
+            java: temurin@11
           - project: rootJS
             java: temurin@11
           - project: rootNative
@@ -94,6 +98,10 @@ jobs:
 
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck
+
+      - name: Check headers and formatting
+        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: scalaJSLink
         if: matrix.project == 'rootJS'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,34 @@
+version=3.7.3
+maxColumn = 120
+assumeStandardLibraryStripMargin = true
+
+align {
+  preset = none
+  stripMargin = true
+}
+
+danglingParentheses {
+  callSite = false
+}
+
+newlines {
+  source = keep
+}
+
+runner.dialect = scala213source3
+fileOverride {
+  "glob:**/*.sbt" {
+    runner.dialect = sbt1
+  }
+  "glob:**/src/{main,test}/scala-2.12-/**" {
+    runner.dialect = scala212source3
+  }
+  "glob:**/src/{main,test}/scala-3/**" {
+    runner.dialect = scala3
+  }
+}
+project.excludeFilters = [
+  "scalafix/*"
+]
+
+project.includePaths = [] # temporarily disable formatting

--- a/bench/src/main/scala/org/scalacheck/bench/GenBench.scala
+++ b/bench/src/main/scala/org/scalacheck/bench/GenBench.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.bench
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := "scalacheck"
 ThisBuild / organization := "org.scalacheck"
 ThisBuild / organizationName := "Typelevel"
 ThisBuild / homepage := Some(url("http://www.scalacheck.org"))
-ThisBuild / licenses := Seq("BSD 3-clause" -> url("https://opensource.org/licenses/BSD-3-Clause"))
+ThisBuild / licenses := Seq("BSD-3-Clause" -> url("https://opensource.org/licenses/BSD-3-Clause"))
 ThisBuild / developers := List(
   Developer(
     id    = "rickynils",

--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,14 @@ ThisBuild / tlMimaPreviousVersions ++= Set(
 ThisBuild / tlVersionIntroduced := Map("3" -> "1.15.3")
 
 lazy val root = tlCrossRootProject.aggregate(core, bench)
+  .settings(
+    Compile / headerSources ++= Seq(
+      "codegen.scala",
+      "CustomHeaderPlugin.scala"
+    ).map {
+      BuildPaths.projectStandard((ThisBuild / baseDirectory).value) / _
+    }
+  )
 
 lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("core"))

--- a/core/js/src/main/scala/org/scalacheck/Platform.scala
+++ b/core/js/src/main/scala/org/scalacheck/Platform.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/main/scala/org/scalacheck/Platform.scala
+++ b/core/jvm/src/main/scala/org/scalacheck/Platform.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/test/scala/org/scalacheck/ChooseSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/ChooseSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/test/scala/org/scalacheck/CogenSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/CogenSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/test/scala/org/scalacheck/LazyPropertiesSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/LazyPropertiesSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/test/scala/org/scalacheck/PropertyFilterSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/PropertyFilterSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/test/scala/org/scalacheck/SerializabilitySpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/SerializabilitySpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/test/scala/org/scalacheck/ShrinkSpecificationJVM.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/ShrinkSpecificationJVM.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/test/scala/org/scalacheck/TestAll.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/TestAll.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/test/scala/org/scalacheck/TestSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/TestSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/test/scala/org/scalacheck/commands/CommandsShrinkSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/commands/CommandsShrinkSpecification.scala
@@ -1,3 +1,12 @@
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
+
 package org.scalacheck.commands
 
 import org.scalacheck.Prop.forAll

--- a/core/jvm/src/test/scala/org/scalacheck/commands/CommandsSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/commands/CommandsSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.commands
 

--- a/core/jvm/src/test/scala/org/scalacheck/examples/IntMapSpec.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/examples/IntMapSpec.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/jvm/src/test/scala/org/scalacheck/examples/StringUtils.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/examples/StringUtils.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.example
 

--- a/core/jvm/src/test/scala/org/scalacheck/rng/SeedSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/rng/SeedSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 package rng

--- a/core/jvm/src/test/scala/org/scalacheck/time/ShrinkSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/time/ShrinkSpecification.scala
@@ -1,3 +1,12 @@
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
+
 package org.scalacheck.time
 
 import java.time._

--- a/core/native/src/main/scala/org/scalacheck/Platform.scala
+++ b/core/native/src/main/scala/org/scalacheck/Platform.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/main/scala-2.12-/org/scalacheck/ScalaVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.12-/org/scalacheck/ScalaVersionSpecific.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/main/scala-2.12-/org/scalacheck/util/BuildableVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.12-/org/scalacheck/util/BuildableVersionSpecific.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.util
 

--- a/core/shared/src/main/scala-2.13+/org/scalacheck/ScalaVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.13+/org/scalacheck/ScalaVersionSpecific.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/main/scala-2.13+/org/scalacheck/util/BuildableVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.13+/org/scalacheck/util/BuildableVersionSpecific.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.util
 

--- a/core/shared/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/main/scala/org/scalacheck/Cogen.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Cogen.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/main/scala/org/scalacheck/Gen.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Gen.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/main/scala/org/scalacheck/Prop.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Prop.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/main/scala/org/scalacheck/Properties.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Properties.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
+++ b/core/shared/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/main/scala/org/scalacheck/Shrink.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Shrink.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/main/scala/org/scalacheck/Test.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Test.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/main/scala/org/scalacheck/commands/Commands.scala
+++ b/core/shared/src/main/scala/org/scalacheck/commands/Commands.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.commands
 

--- a/core/shared/src/main/scala/org/scalacheck/rng/Seed.scala
+++ b/core/shared/src/main/scala/org/scalacheck/rng/Seed.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 package rng

--- a/core/shared/src/main/scala/org/scalacheck/time/JavaTimeArbitrary.scala
+++ b/core/shared/src/main/scala/org/scalacheck/time/JavaTimeArbitrary.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.time
 

--- a/core/shared/src/main/scala/org/scalacheck/time/JavaTimeChoose.scala
+++ b/core/shared/src/main/scala/org/scalacheck/time/JavaTimeChoose.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.time
 

--- a/core/shared/src/main/scala/org/scalacheck/time/JavaTimeCogen.scala
+++ b/core/shared/src/main/scala/org/scalacheck/time/JavaTimeCogen.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.time
 

--- a/core/shared/src/main/scala/org/scalacheck/time/JavaTimeShrink.scala
+++ b/core/shared/src/main/scala/org/scalacheck/time/JavaTimeShrink.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.time
 

--- a/core/shared/src/main/scala/org/scalacheck/util/Buildable.scala
+++ b/core/shared/src/main/scala/org/scalacheck/util/Buildable.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.util
 

--- a/core/shared/src/main/scala/org/scalacheck/util/CmdLineParser.scala
+++ b/core/shared/src/main/scala/org/scalacheck/util/CmdLineParser.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.util
 

--- a/core/shared/src/main/scala/org/scalacheck/util/ConsoleReporter.scala
+++ b/core/shared/src/main/scala/org/scalacheck/util/ConsoleReporter.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.util
 

--- a/core/shared/src/main/scala/org/scalacheck/util/FreqMap.scala
+++ b/core/shared/src/main/scala/org/scalacheck/util/FreqMap.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.util
 

--- a/core/shared/src/main/scala/org/scalacheck/util/Pretty.scala
+++ b/core/shared/src/main/scala/org/scalacheck/util/Pretty.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.util
 

--- a/core/shared/src/test/scala-2.12-/org/scalacheck/time/OrderingVersionSpecific.scala
+++ b/core/shared/src/test/scala-2.12-/org/scalacheck/time/OrderingVersionSpecific.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.time
 

--- a/core/shared/src/test/scala-2.13+/org/scalacheck/time/OrderingVersionSpecific.scala
+++ b/core/shared/src/test/scala-2.13+/org/scalacheck/time/OrderingVersionSpecific.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.time
 

--- a/core/shared/src/test/scala/org/scalacheck/NoPropertyNestingSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/NoPropertyNestingSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/test/scala/org/scalacheck/ShrinkSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/ShrinkSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/test/scala/org/scalacheck/StatsSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/StatsSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 

--- a/core/shared/src/test/scala/org/scalacheck/TestFingerprint.scala
+++ b/core/shared/src/test/scala/org/scalacheck/TestFingerprint.scala
@@ -1,3 +1,12 @@
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
+
 package org.scalacheck
 
 class PropsClass extends Properties("TestFingerprint") {

--- a/core/shared/src/test/scala/org/scalacheck/examples/Examples.scala
+++ b/core/shared/src/test/scala/org/scalacheck/examples/Examples.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.examples
 

--- a/core/shared/src/test/scala/org/scalacheck/examples/MathSpec.scala
+++ b/core/shared/src/test/scala/org/scalacheck/examples/MathSpec.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck.examples
 

--- a/core/shared/src/test/scala/org/scalacheck/util/BuildableSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/util/BuildableSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 package util

--- a/core/shared/src/test/scala/org/scalacheck/util/PrettySpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/util/PrettySpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package org.scalacheck
 package util

--- a/core/shared/src/test/scala/scala/StringSpecification.scala
+++ b/core/shared/src/test/scala/scala/StringSpecification.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 package scala
 

--- a/project/CustomHeaderPlugin.scala
+++ b/project/CustomHeaderPlugin.scala
@@ -1,0 +1,22 @@
+import sbt.*
+import de.heikoseeberger.sbtheader.HeaderPlugin
+
+object CustomHeaderPlugin extends AutoPlugin {
+  import HeaderPlugin.autoImport.*
+
+  override def trigger = allRequirements
+  override def requires = HeaderPlugin
+
+  override def projectSettings = Seq(
+    headerLicense := Some(HeaderLicense.Custom(licenseTest))
+  )
+
+  private[this] final val licenseTest =
+    """|ScalaCheck                                                           
+       |Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+       |http://www.scalacheck.org                                            
+       |                                                                     
+       |This software is released under the terms of the Revised BSD License.
+       |There is NO WARRANTY. See the file LICENSE for the full text.        
+       |""".stripMargin
+}

--- a/project/CustomHeaderPlugin.scala
+++ b/project/CustomHeaderPlugin.scala
@@ -1,3 +1,12 @@
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
+
 import sbt.*
 import de.heikoseeberger.sbtheader.HeaderPlugin
 

--- a/project/codegen.scala
+++ b/project/codegen.scala
@@ -1,11 +1,11 @@
-/*-------------------------------------------------------------------------*\
-**  ScalaCheck                                                             **
-**  Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.          **
-**  http://www.scalacheck.org                                              **
-**                                                                         **
-**  This software is released under the terms of the Revised BSD License.  **
-**  There is NO WARRANTY. See the file LICENSE for the full text.          **
-\*------------------------------------------------------------------------ */
+/*
+ * ScalaCheck                                                           
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
+ * http://www.scalacheck.org                                            
+ *                                                                      
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.        
+ */
 
 // Generates Arbitrary instance for tuples and functions
 

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -3,6 +3,4 @@ addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.10")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.4")
-val sbtTypelevelVersion = "0.4.21"
-addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % sbtTypelevelVersion)
-addSbtPlugin("org.typelevel" % "sbt-typelevel-settings" % sbtTypelevelVersion)
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.21")


### PR DESCRIPTION
This PR should technically precede #950.
Initially my intent was to just introduce scalafmt in here, but then I realized that it would be easier if we would have the **sbt-header** incorporated first. So here this PR is.

A couple of things to mention:
1. Most of the source files had their own headers already which do not correspond to any of the standard headers that **sbt-header** provides out of the box. So I created a custom header which is just a copy of the original one, but uses an **sbt-header** default style. See `project/CustomHeaderPlugin.scala`.
2. The **sbt-header** does not cover source files that are loaded into and used by SBT directly (i.e. those located in the `project` dir). However, **scalacheck** has `project/codegen.scala` along with the aforementioned `CustomHeaderPlugin.scala`. So I plugged them in to the sbt-header in `build.sbt` (see settings for the `root` project).
3. For the full version of **sbt-typelevel** the **.scalafmt.conf** should exist. So I created one but disabled any formatting in it for now. I think, it'd still be better to enable it in a separate follow up PR.