### PR TITLE
Fix trailing whitespaces in headers

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Header whitespace cleanup
+0b26b5e6dbcf3e6beeca806297f848f41dde899b

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # Header whitespace cleanup
+b8564609df3c849b3a258a411e0de645d4e8c7a0
 0b26b5e6dbcf3e6beeca806297f848f41dde899b

--- a/bench/src/main/scala/org/scalacheck/bench/GenBench.scala
+++ b/bench/src/main/scala/org/scalacheck/bench/GenBench.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.bench

--- a/core/js/src/main/scala/org/scalacheck/Platform.scala
+++ b/core/js/src/main/scala/org/scalacheck/Platform.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/main/scala/org/scalacheck/Platform.scala
+++ b/core/jvm/src/main/scala/org/scalacheck/Platform.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/ChooseSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/ChooseSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/CogenSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/CogenSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/LazyPropertiesSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/LazyPropertiesSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/PropertyFilterSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/PropertyFilterSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/SerializabilitySpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/SerializabilitySpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/ShrinkSpecificationJVM.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/ShrinkSpecificationJVM.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/TestAll.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/TestAll.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/TestSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/TestSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/commands/CommandsShrinkSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/commands/CommandsShrinkSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.commands

--- a/core/jvm/src/test/scala/org/scalacheck/commands/CommandsSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/commands/CommandsSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.commands

--- a/core/jvm/src/test/scala/org/scalacheck/examples/IntMapSpec.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/examples/IntMapSpec.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/examples/StringUtils.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/examples/StringUtils.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.example

--- a/core/jvm/src/test/scala/org/scalacheck/rng/SeedSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/rng/SeedSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/jvm/src/test/scala/org/scalacheck/time/ShrinkSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/time/ShrinkSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.time

--- a/core/native/src/main/scala/org/scalacheck/Platform.scala
+++ b/core/native/src/main/scala/org/scalacheck/Platform.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/main/scala-2.12-/org/scalacheck/ScalaVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.12-/org/scalacheck/ScalaVersionSpecific.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/main/scala-2.12-/org/scalacheck/util/BuildableVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.12-/org/scalacheck/util/BuildableVersionSpecific.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.util

--- a/core/shared/src/main/scala-2.13+/org/scalacheck/ScalaVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.13+/org/scalacheck/ScalaVersionSpecific.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/main/scala-2.13+/org/scalacheck/util/BuildableVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.13+/org/scalacheck/util/BuildableVersionSpecific.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.util

--- a/core/shared/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/main/scala/org/scalacheck/Cogen.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Cogen.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/main/scala/org/scalacheck/Gen.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Gen.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/main/scala/org/scalacheck/Prop.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Prop.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/main/scala/org/scalacheck/Properties.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Properties.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
+++ b/core/shared/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/main/scala/org/scalacheck/Shrink.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Shrink.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/main/scala/org/scalacheck/Test.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Test.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/main/scala/org/scalacheck/commands/Commands.scala
+++ b/core/shared/src/main/scala/org/scalacheck/commands/Commands.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.commands

--- a/core/shared/src/main/scala/org/scalacheck/rng/Seed.scala
+++ b/core/shared/src/main/scala/org/scalacheck/rng/Seed.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/main/scala/org/scalacheck/time/JavaTimeArbitrary.scala
+++ b/core/shared/src/main/scala/org/scalacheck/time/JavaTimeArbitrary.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.time

--- a/core/shared/src/main/scala/org/scalacheck/time/JavaTimeChoose.scala
+++ b/core/shared/src/main/scala/org/scalacheck/time/JavaTimeChoose.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.time

--- a/core/shared/src/main/scala/org/scalacheck/time/JavaTimeCogen.scala
+++ b/core/shared/src/main/scala/org/scalacheck/time/JavaTimeCogen.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.time

--- a/core/shared/src/main/scala/org/scalacheck/time/JavaTimeShrink.scala
+++ b/core/shared/src/main/scala/org/scalacheck/time/JavaTimeShrink.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.time

--- a/core/shared/src/main/scala/org/scalacheck/util/Buildable.scala
+++ b/core/shared/src/main/scala/org/scalacheck/util/Buildable.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.util

--- a/core/shared/src/main/scala/org/scalacheck/util/CmdLineParser.scala
+++ b/core/shared/src/main/scala/org/scalacheck/util/CmdLineParser.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.util

--- a/core/shared/src/main/scala/org/scalacheck/util/ConsoleReporter.scala
+++ b/core/shared/src/main/scala/org/scalacheck/util/ConsoleReporter.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.util

--- a/core/shared/src/main/scala/org/scalacheck/util/FreqMap.scala
+++ b/core/shared/src/main/scala/org/scalacheck/util/FreqMap.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.util

--- a/core/shared/src/main/scala/org/scalacheck/util/Pretty.scala
+++ b/core/shared/src/main/scala/org/scalacheck/util/Pretty.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.util

--- a/core/shared/src/test/scala-2.12-/org/scalacheck/time/OrderingVersionSpecific.scala
+++ b/core/shared/src/test/scala-2.12-/org/scalacheck/time/OrderingVersionSpecific.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.time

--- a/core/shared/src/test/scala-2.13+/org/scalacheck/time/OrderingVersionSpecific.scala
+++ b/core/shared/src/test/scala-2.13+/org/scalacheck/time/OrderingVersionSpecific.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.time

--- a/core/shared/src/test/scala/org/scalacheck/NoPropertyNestingSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/NoPropertyNestingSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/test/scala/org/scalacheck/ShrinkSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/ShrinkSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/test/scala/org/scalacheck/StatsSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/StatsSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/test/scala/org/scalacheck/TestFingerprint.scala
+++ b/core/shared/src/test/scala/org/scalacheck/TestFingerprint.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/test/scala/org/scalacheck/examples/Examples.scala
+++ b/core/shared/src/test/scala/org/scalacheck/examples/Examples.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.examples

--- a/core/shared/src/test/scala/org/scalacheck/examples/MathSpec.scala
+++ b/core/shared/src/test/scala/org/scalacheck/examples/MathSpec.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck.examples

--- a/core/shared/src/test/scala/org/scalacheck/util/BuildableSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/util/BuildableSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/test/scala/org/scalacheck/util/PrettySpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/util/PrettySpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package org.scalacheck

--- a/core/shared/src/test/scala/scala/StringSpecification.scala
+++ b/core/shared/src/test/scala/scala/StringSpecification.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 package scala

--- a/project/CustomHeaderPlugin.scala
+++ b/project/CustomHeaderPlugin.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 import sbt.*

--- a/project/CustomHeaderPlugin.scala
+++ b/project/CustomHeaderPlugin.scala
@@ -21,11 +21,11 @@ object CustomHeaderPlugin extends AutoPlugin {
   )
 
   private[this] final val licenseTest =
-    """|ScalaCheck                                                           
-       |Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
-       |http://www.scalacheck.org                                            
-       |                                                                     
+    """|ScalaCheck
+       |Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+       |http://www.scalacheck.org
+       |
        |This software is released under the terms of the Revised BSD License.
-       |There is NO WARRANTY. See the file LICENSE for the full text.        
+       |There is NO WARRANTY. See the file LICENSE for the full text.
        |""".stripMargin
 }

--- a/project/codegen.scala
+++ b/project/codegen.scala
@@ -1,10 +1,10 @@
 /*
- * ScalaCheck                                                           
- * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.        
- * http://www.scalacheck.org                                            
- *                                                                      
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
  * This software is released under the terms of the Revised BSD License.
- * There is NO WARRANTY. See the file LICENSE for the full text.        
+ * There is NO WARRANTY. See the file LICENSE for the full text.
  */
 
 // Generates Arbitrary instance for tuples and functions


### PR DESCRIPTION
A follow up for #959.
When I resumed my work on #950, I realized that I overlooked trailing whitespaces in the header template in my last PR and Scalafmt started removing them.
It makes sbt-header and scalafmt incompatible with each other.
I decided to fix the header template and re-apply sbt-header.
Hopefully, it is the last PR regarding the headers and the next one is expected to be the Scalafmt per se.
