### PR TITLE
Add `open` to `Properties` to prevent Scala 3 compile errors

### DIFF
--- a/core/shared/src/main/scala/org/scalacheck/Properties.scala
+++ b/core/shared/src/main/scala/org/scalacheck/Properties.scala
@@ -25,7 +25,7 @@ import util.ConsoleReporter
   * }}}
   */
 @Platform.EnableReflectiveInstantiation
-class Properties(val name: String) {
+open class Properties(val name: String) {
 
   private val props = new scala.collection.mutable.ListBuffer[(String, Prop)]
   private var frozen = false


### PR DESCRIPTION
When extending `Properties` in a Scala 3 code base one currently has to use `scala.language.adhocExtensions`. 
According to the documentation `Properties` is clearly intended for extension.