### PR TITLE
Add buildable for java.util.HashMap

### DIFF
--- a/core/shared/src/main/scala-2.12-/org/scalacheck/util/BuildableVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.12-/org/scalacheck/util/BuildableVersionSpecific.scala
@@ -9,13 +9,19 @@
 
 package org.scalacheck.util
 
-import java.util.ArrayList
+import java.util.{ArrayList, HashMap}
 
 import collection.{Map => _, _}
 import generic.CanBuildFrom
 import scala.collection.mutable.Builder
 
 private[util] trait BuildableVersionSpecific {
+  import scala.collection.JavaConverters._
+  import scala.language.implicitConversions
+
+  implicit def wrapArrayList[T](xs: ArrayList[T]): Traversable[T] = xs.asScala
+  implicit def wrapHashMap[K, V](xs: HashMap[K, V]): Traversable[(K, V)] = xs.asScala
+
   implicit def buildableCanBuildFrom[T, F, C](implicit c: CanBuildFrom[F, T, C]): Buildable[T, C] =
     new Buildable[T, C] {
       def builder = c.apply
@@ -30,6 +36,18 @@ private[util] class ArrayListBuilder[T] extends Builder[T, ArrayList[T]] {
   }
   def clear(): Unit = al.clear()
   def result(): ArrayList[T] = al
+}
+
+private[util] class HashMapBuilder[K, V] extends Builder[(K, V), HashMap[K, V]] {
+  private val hm = new HashMap[K, V]
+
+  def +=(x: (K, V)): this.type = {
+    val (k, v) = x
+    hm.put(k, v)
+    this
+  }
+  def clear(): Unit = hm.clear()
+  def result(): HashMap[K, V] = hm
 }
 
 /** CanBuildFrom instances implementing Serializable, so that the objects capturing those can be serializable too.

--- a/core/shared/src/main/scala-2.12-/org/scalacheck/util/BuildableVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.12-/org/scalacheck/util/BuildableVersionSpecific.scala
@@ -16,12 +16,6 @@ import generic.CanBuildFrom
 import scala.collection.mutable.Builder
 
 private[util] trait BuildableVersionSpecific {
-  import scala.collection.JavaConverters._
-  import scala.language.implicitConversions
-
-  implicit def wrapArrayList[T](xs: ArrayList[T]): Traversable[T] = xs.asScala
-  implicit def wrapHashMap[K, V](xs: HashMap[K, V]): Traversable[(K, V)] = xs.asScala
-
   implicit def buildableCanBuildFrom[T, F, C](implicit c: CanBuildFrom[F, T, C]): Buildable[T, C] =
     new Buildable[T, C] {
       def builder = c.apply

--- a/core/shared/src/main/scala-2.13+/org/scalacheck/util/BuildableVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.13+/org/scalacheck/util/BuildableVersionSpecific.scala
@@ -14,10 +14,6 @@ import scala.collection.mutable.Builder
 import scala.collection.{Map => _, _}
 
 private[util] trait BuildableVersionSpecific {
-  import scala.jdk.CollectionConverters._
-
-  implicit def wrapArrayList[T](xs: ArrayList[T]): Iterable[T] = xs.asScala
-  implicit def wrapHashMap[K, V](xs: HashMap[K, V]): Iterable[(K, V)] = xs.asScala
 
   implicit def buildableFactory[T, C](implicit f: Factory[T, C]): Buildable[T, C] =
     new Buildable[T, C] {

--- a/core/shared/src/main/scala-2.13+/org/scalacheck/util/BuildableVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.13+/org/scalacheck/util/BuildableVersionSpecific.scala
@@ -9,11 +9,16 @@
 
 package org.scalacheck.util
 
-import java.util.ArrayList
+import java.util.{ArrayList, HashMap}
 import scala.collection.mutable.Builder
 import scala.collection.{Map => _, _}
 
 private[util] trait BuildableVersionSpecific {
+  import scala.jdk.CollectionConverters._
+
+  implicit def wrapArrayList[T](xs: ArrayList[T]): Iterable[T] = xs.asScala
+  implicit def wrapHashMap[K, V](xs: HashMap[K, V]): Iterable[(K, V)] = xs.asScala
+
   implicit def buildableFactory[T, C](implicit f: Factory[T, C]): Buildable[T, C] =
     new Buildable[T, C] {
       def builder = f.newBuilder
@@ -28,6 +33,17 @@ private[util] class ArrayListBuilder[T] extends Builder[T, ArrayList[T]] {
   }
   def clear(): Unit = al.clear()
   def result(): ArrayList[T] = al
+}
+
+private[util] class HashMapBuilder[K, V] extends Builder[(K, V), HashMap[K, V]] {
+  private val hm = new HashMap[K, V]
+  def addOne(x: (K, V)): this.type = {
+    val (k, v) = x
+    hm.put(k, v)
+    this
+  }
+  def clear(): Unit = hm.clear()
+  def result(): HashMap[K, V] = hm
 }
 
 /** Factory instances implementing Serializable, so that the objects capturing those can be serializable too.

--- a/core/shared/src/main/scala/org/scalacheck/util/Buildable.scala
+++ b/core/shared/src/main/scala/org/scalacheck/util/Buildable.scala
@@ -22,10 +22,16 @@ trait Buildable[T, C] extends Serializable {
 }
 
 object Buildable extends BuildableVersionSpecific {
-  import java.util.ArrayList
+  import java.util.{ArrayList, HashMap}
+
   implicit def buildableArrayList[T]: Buildable[T, ArrayList[T]] =
     new Buildable[T, ArrayList[T]] {
       def builder = new ArrayListBuilder[T]
+    }
+
+  implicit def buildableHashMap[K, V]: Buildable[(K, V), HashMap[K, V]] =
+    new Buildable[(K, V), HashMap[K, V]] {
+      def builder = new HashMapBuilder[K, V]
     }
 
   def buildableSeq[T]: Buildable[T, Seq[T]] =

--- a/core/shared/src/test/scala/org/scalacheck/util/BuildableSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/util/BuildableSpecification.scala
@@ -21,6 +21,11 @@ object BuildableSpecification {
       evt: C[String] => Traversable[String]
   ) = Gen.containerOf[C, String](Gen.alphaStr)
 
+  def buildable[C[_, _]](implicit
+      evb: Buildable[(String, Long), C[String, Long]],
+      evt: C[String, Long] => Traversable[(String, Long)]
+  ) = Gen.buildableOf[C[String, Long], (String, Long)](Gen.zip(Gen.alphaStr, Gen.long))
+
   implicit val listGen: Gen[List[String]] = container[List]
 
   implicit val streamGen: Gen[Stream[String]] = container[Stream]
@@ -49,14 +54,16 @@ object BuildableSpecification {
 
   implicit val trieIteratorGen: Gen[immutable.Queue[String]] = container[immutable.Queue]
 
-  implicit val arrayListGen: Gen[java.util.ArrayList[String]] = container[java.util.ArrayList]
-
-  def buildable[C[_, _]](implicit
-      evb: Buildable[(String, Long), C[String, Long]],
-      evt: C[String, Long] => Traversable[(String, Long)]
-  ) = Gen.buildableOf[C[String, Long], (String, Long)](for (str <- Gen.alphaStr; lng <- Gen.long) yield (str, lng))
-
   implicit val mapGen: Gen[Map[String, Long]] = buildable[Map]
 
-  implicit val hashMapGen: Gen[java.util.HashMap[String, Long]] = buildable[java.util.HashMap]
+  Gen.buildableOf[Map[String, Int], (String, Int)](Gen.zip(Gen.alphaStr, Gen.choose(0, 100)))
+
+  // java containers
+  {
+    import scala.collection.convert.ImplicitConversionsToScala._
+
+    implicit val arrayListGen: Gen[java.util.ArrayList[String]] = container[java.util.ArrayList]
+
+    implicit val hashMapGen: Gen[java.util.HashMap[String, Long]] = buildable[java.util.HashMap]
+  }
 }

--- a/core/shared/src/test/scala/org/scalacheck/util/BuildableSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/util/BuildableSpecification.scala
@@ -12,6 +12,7 @@ package util
 
 import scala.collection._
 
+import Buildable._
 import ScalaVersionSpecific._
 
 object BuildableSpecification {
@@ -47,4 +48,15 @@ object BuildableSpecification {
   implicit val iterableGen: Gen[immutable.Iterable[String]] = container[immutable.Iterable]
 
   implicit val trieIteratorGen: Gen[immutable.Queue[String]] = container[immutable.Queue]
+
+  implicit val arrayListGen: Gen[java.util.ArrayList[String]] = container[java.util.ArrayList]
+
+  def buildable[C[_, _]](implicit
+      evb: Buildable[(String, Long), C[String, Long]],
+      evt: C[String, Long] => Traversable[(String, Long)]
+  ) = Gen.buildableOf[C[String, Long], (String, Long)](for (str <- Gen.alphaStr; lng <- Gen.long) yield (str, lng))
+
+  implicit val mapGen: Gen[Map[String, Long]] = buildable[Map]
+
+  implicit val hashMapGen: Gen[java.util.HashMap[String, Long]] = buildable[java.util.HashMap]
 }

--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -478,14 +478,13 @@ They take another generator as argument, that is responsible for generating the 
 You can use it in the following way:
 
 ```scala
-implicit genInt: Gen[Int] = Gen.oneOf(1, 3, 5)
-val genIntList            = Gen.containerOf[List, Int]
-
+val genInt: Gen[Int]  = Gen.oneOf(1, 3, 5)
+val genIntList        = Gen.containerOf[List, Int](genInt)
 val genStringLazyList = Gen.containerOf[LazyList, String](Gen.alphaStr)
 val genBoolArray      = Gen.containerOf[Array, Boolean](Gen.const(true))
 
-implicit getTuple: Gen[(String, Int)] = Gen.zip(Gen.alphaStr, Gen.choose(0, 100))
-val genMap                            = Gen.buildableOf[Map[String, Int], (String, Int)]
+val genTuple: Gen[(String, Int)] = Gen.zip(Gen.alphaStr, Gen.choose(0, 100))
+val genMap                       = Gen.buildableOf[Map[String, Int], (String, Int)](genTuple)
 ```
 
 By default, ScalaCheck supports generation of `List`, `Stream` (Scala 2.10 -

--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -468,32 +468,39 @@ value ultimately reported as failing might not satisfy the condition given to
 case that does. To avoid confusion, the corresponding shrink for the type can
 use `suchThat` method too.
 
-#### Generating Containers
+#### Generating Buildables and Containers
 
-There is a special generator, `Gen.containerOf`, that generates containers such
-as lists and arrays. They take another generator as argument, that is
-responsible for generating the individual items. You can use it in the
-following way:
+There are special generators
+* `Gen.buildableOf`, that generates any buildable collection
+* `Gen.containerOf`, a convenience method for single parameter buildable like lists and arrays
+
+They take another generator as argument, that is responsible for generating the individual items.
+You can use it in the following way:
 
 ```scala
-val genIntList        = Gen.containerOf[List,Int](Gen.oneOf(1, 3, 5))
+implicit genInt: Gen[Int] = Gen.oneOf(1, 3, 5)
+val genIntList            = Gen.containerOf[List, Int]
 
-val genStringLazyList = Gen.containerOf[LazyList,String](Gen.alphaStr)
+val genStringLazyList = Gen.containerOf[LazyList, String](Gen.alphaStr)
+val genBoolArray      = Gen.containerOf[Array, Boolean](Gen.const(true))
 
-val genBoolArray      = Gen.containerOf[Array,Boolean](true)
+implicit getTuple: Gen[(String, Int)] = Gen.zip(Gen.alphaStr, Gen.choose(0, 100))
+val genMap                            = Gen.buildableOf[Map[String, Int], (String, Int)]
 ```
 
 By default, ScalaCheck supports generation of `List`, `Stream` (Scala 2.10 -
-2.12, deprecated in 2.13), `LazyList` (Scala 2.13), `Set`, `Array`, and
-`ArrayList` (from `java.util`). You can add support for additional containers
-by adding implicit `Buildable` instances. See `Buildable.scala` for examples.
+2.12, deprecated in 2.13), `LazyList` (Scala 2.13), `Set`, `Array` and `Map`.
+Additionally, ScalaCheck can generate `java.util.ArrayList` and `java.util.HashMap` when an implicit 
+`Traversable` conversion evidence is in scope.
+
+You can add support for additional containers by adding implicit `Buildable` instances.
+See `Buildable.scala` for examples.
 
 There is also `Gen.nonEmptyContainerOf` for generating non-empty containers, and
 `Gen.containerOfN` for generating containers of a given size.
 
 To generate a container by picking an arbitrary number of elements use
-`Gen.someOf`, or by picking one or more elements with
-`Gen.atLeastOne`.
+`Gen.someOf`, or by picking one or more elements with `Gen.atLeastOne`.
 
 ```scala
 val zeroOrMoreDigits = Gen.someOf(1 to 9)


### PR DESCRIPTION
As `java.util.ArrayList` is supported in `containerOf`, introduce builder to generate `java.util.HashMap` from tuple generator.

The doc states `java.util.ArrayList` is supported by default, but the implicit evidence `evt: C[T] => Traversable[T]` is missing. Adding it in `BuildableVersionSpecific`.

Add new instances in `BuildableSpecification` to verify compile ability.
 