### PR TITLE
Enable lazy construction of label strings

### DIFF
--- a/core/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/core/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -583,6 +583,8 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
       }
       val avg = sum / n
       s"average = $avg" |: avg >= 0.49 && avg <= 0.51
+      s"average = $avg".ensuring(false, "eager evaluation") =|= avg >= 0.49 && avg <= 0.51
+      avg >= 0.49 && avg <= 0.51 =|= s"average = $avg"
     }
 
   property("uniform long #209") = {

--- a/core/shared/src/main/scala-2/org/scalacheck/package.scala
+++ b/core/shared/src/main/scala-2/org/scalacheck/package.scala
@@ -1,0 +1,29 @@
+/*
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.
+ */
+
+package org.scalacheck
+
+object `package` {
+  implicit class `by-name label :|`(private val prop: Prop) extends AnyVal {
+
+    /** Label this property.
+      *
+      * The label is evaluated lazily. The operator name is chosen for its precedence btween boolean operators and
+      * others.
+      */
+    def =|=(label: => String): Prop = prop.map(_.label(label))
+  }
+  // chained implicit for true =|= label
+  implicit class `by-name label bool :| label`(private val bool: Boolean) extends AnyVal {
+    def =|=(label: => String): Prop = (bool: Prop).=|=(label)
+  }
+  implicit class `by-name label |: prop`(label: => String) {
+    def =|=(prop: Prop): Prop = prop.=|=(label)
+  }
+}

--- a/core/shared/src/main/scala-3/org/scalacheck/package.scala
+++ b/core/shared/src/main/scala-3/org/scalacheck/package.scala
@@ -1,0 +1,21 @@
+/*
+ * ScalaCheck
+ * Copyright (c) 2007-2021 Rickard Nilsson. All rights reserved.
+ * http://www.scalacheck.org
+ *
+ * This software is released under the terms of the Revised BSD License.
+ * There is NO WARRANTY. See the file LICENSE for the full text.
+ */
+
+package org.scalacheck
+
+object `package` {
+
+  /** Label this property. The label is evaluated lazily.
+    *
+    * The operator name is chosen for its precedence between boolean operators and others.
+    */
+  extension (prop: Prop) def =|=(label: => String): Prop = prop.map(_.label(label))
+
+  extension (label: => String) def =|=(prop: Prop): Prop = prop.map(_.label(label))
+}

--- a/core/shared/src/test/scala/org/scalacheck/StatsSpecification.scala
+++ b/core/shared/src/test/scala/org/scalacheck/StatsSpecification.scala
@@ -87,7 +87,7 @@ object StatsSpecification extends Properties("Stats") {
 
   case class Bounds(min: Double, max: Double) {
     def contains(x: Double): Prop =
-      Prop(min <= x && x <= max) :| s"($min <= $x <= $max) was false"
+      Prop(min <= x && x <= max) =|= s"($min <= $x <= $max) was false"
   }
 
   implicit class MakeBounds(val n: Double) extends AnyVal {


### PR DESCRIPTION
A different take on https://github.com/typelevel/scalacheck/pull/979

Instead of recycling `|:` for labeling, use `=|=` for improved symmetry and operator precedence.

A second commit follows up scalafmt config by "fixing" star alignment in doc comments. Edit: That hassle is reserved for another effort.