### PR TITLE
Update tlBaseVersion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
   )
 )
 
-ThisBuild / tlBaseVersion := "1.19"
+ThisBuild / tlBaseVersion := "1.20"
 ThisBuild / tlMimaPreviousVersions ++= Set(
   // manually added because tags are not v-prefixed
   "1.14.0",


### PR DESCRIPTION
Fix build error

```
java.lang.RuntimeException: Your tlBaseVersion 1.19 is behind the latest tag 1.20.0
	at scala.sys.package$.error(package.scala:30)
	at org.typelevel.sbt.TypelevelVersioningPlugin$.$anonfun$buildSettings$12(TypelevelVersioningPlugin.scala:95)
	at scala.Option.flatMap(Option.scala:271)
	at org.typelevel.sbt.TypelevelVersioningPlugin$.$anonfun$buildSettings$10(TypelevelVersioningPlugin.scala:93)
	at scala.Option.getOrElse(Option.scala:189)
	at org.typelevel.sbt.TypelevelVersioningPlugin$.$anonfun$buildSettings$6(TypelevelVersioningPlugin.scala:86)
	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
	at sbt.internal.util.EvaluateSettings$MixedNode.evaluate0(INode.scala:229)
	at sbt.internal.util.EvaluateSettings$INode.evaluate(INode.scala:171)
	at sbt.internal.util.EvaluateSettings.$anonfun$submitEvaluate$1(INode.scala:88)
	at sbt.internal.util.EvaluateSettings.sbt$internal$util$EvaluateSettings$$run0(INode.scala:100)
	at sbt.internal.util.EvaluateSettings$$anon$3.run(INode.scala:95)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
[error] Your tlBaseVersion 1.19 is behind the latest tag 1.20.0
[error] Use 'last' for the full log.
```

<!--

If you have not, please read the project [contribution guidelines](https://typelevel.org/projects/contributing-guide.html) before opening a pull request. 

For reference, make sure that:

- you respect the Typelevel code of conduct
- your description, documentation and comments are human written
- your contribution is not subject to any copyrights or patents that are incompatible with the project license
- you are submitting a single self-contained change
- you understand what you are contributing
- you disclose any code not written by you
- you replace these notes with a clear and succinct description

Please also tag any related issues or PRs by referencing their number prefixed with a hash (#), eg. #12345, or a link if they are in a different repository.

-->
